### PR TITLE
API v18 support

### DIFF
--- a/src/main/java/org/rundeck/client/api/RundeckApi.java
+++ b/src/main/java/org/rundeck/client/api/RundeckApi.java
@@ -33,6 +33,17 @@ public interface RundeckApi {
             @Query("idlist") String idlist
     );
 
+    /**
+     * new api
+     * @param jobid
+     * @return
+     */
+    @Headers("Accept: application/json")
+    @GET("job/{jobid}/info")
+    Call<ScheduledJobItem> getJobInfo(
+            @Path("jobid") String jobid
+    );
+
 
     @GET("project/{project}/jobs/export")
     Call<ResponseBody> exportJobs(
@@ -445,7 +456,6 @@ public interface RundeckApi {
      * <a href="http://rundeck.org/docs/api/index.html#delete-a-token">Delete a Token</a>
      *
      * @param id token
-     *
      */
     @Headers("Accept: application/json")
     @DELETE("token/{id}")

--- a/src/main/java/org/rundeck/client/api/RundeckApi.java
+++ b/src/main/java/org/rundeck/client/api/RundeckApi.java
@@ -11,7 +11,9 @@ import retrofit2.http.*;
 
 import java.io.File;
 import java.net.URL;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by greg on 3/28/16.
@@ -250,6 +252,14 @@ public interface RundeckApi {
             @Query("loglevel") String loglevel,
             @Query("filter") String filter,
             @Query("asUser") String user
+    );
+
+    @Headers("Accept: application/json")
+    @POST("job/{id}/executions")
+    Call<Execution> runJob(
+            @Path("id") String id,
+            @Body JobRun jobRun
+
     );
 
     //key storage

--- a/src/main/java/org/rundeck/client/api/model/DateInfo.java
+++ b/src/main/java/org/rundeck/client/api/model/DateInfo.java
@@ -16,8 +16,18 @@ public class DateInfo {
     public String date;
     public long unixtime;
 
-    Date toDate() throws ParseException {
-        SimpleDateFormat asdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+    public DateInfo(final String date) {
+        this.date = date;
+    }
+
+    public DateInfo() {
+    }
+
+    public Date toDate() throws ParseException {
+        return toDate("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    }
+    public Date toDate(final String format) throws ParseException {
+        SimpleDateFormat asdf = new SimpleDateFormat(format, Locale.US);
         return asdf.parse(date);
     }
 

--- a/src/main/java/org/rundeck/client/api/model/JobItem.java
+++ b/src/main/java/org/rundeck/client/api/model/JobItem.java
@@ -5,6 +5,10 @@ import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.Root;
 
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * Created by greg on 3/28/16.
  */
@@ -24,6 +28,9 @@ public class JobItem {
     private String href;
     @Element(required = false)
     private String permalink;
+
+    @Attribute(required = false)
+    private Long averageDuration;
 
     public String getId() {
         return id;
@@ -94,7 +101,27 @@ public class JobItem {
                '}';
     }
 
+    public Map<Object, Object> toMap() {
+        HashMap<Object, Object> map = new LinkedHashMap<>();
+        map.put("id", getId());
+        map.put("name", getName());
+        map.put("group", getGroup());
+        map.put("project", getProject());
+        if(null!=getAverageDuration()){
+            map.put("averageDuration", getAverageDuration());
+        }
+        return map;
+    }
+
     public String toBasicString() {
         return String.format("[%s] %s%s", id, group != null ? group + "/" : "", name);
+    }
+
+    public Long getAverageDuration() {
+        return averageDuration;
+    }
+
+    public void setAverageDuration(Long averageDuration) {
+        this.averageDuration = averageDuration;
     }
 }

--- a/src/main/java/org/rundeck/client/api/model/JobRun.java
+++ b/src/main/java/org/rundeck/client/api/model/JobRun.java
@@ -1,0 +1,71 @@
+package org.rundeck.client.api.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * Parameters to run a job
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class JobRun {
+    private String asUser;
+    private String argString;
+    private String loglevel;
+    private String filter;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssX")
+    private Date runAtTime;
+    private Map<String, String> options;
+
+    public String getAsUser() {
+        return asUser;
+    }
+
+    public void setAsUser(String asUser) {
+        this.asUser = asUser;
+    }
+
+    public String getArgString() {
+        return argString;
+    }
+
+    public void setArgString(String argString) {
+        this.argString = argString;
+    }
+
+    public String getLoglevel() {
+        return loglevel;
+    }
+
+    public void setLoglevel(String loglevel) {
+        this.loglevel = loglevel;
+    }
+
+    public String getFilter() {
+        return filter;
+    }
+
+    public void setFilter(String filter) {
+        this.filter = filter;
+    }
+
+    public Date getRunAtTime() {
+        return runAtTime;
+    }
+
+    public void setRunAtTime(Date runAtTime) {
+        this.runAtTime = runAtTime;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(Map<String, String> options) {
+        this.options = options;
+    }
+}

--- a/src/main/java/org/rundeck/client/api/model/ScheduledJobItem.java
+++ b/src/main/java/org/rundeck/client/api/model/ScheduledJobItem.java
@@ -16,7 +16,7 @@ public class ScheduledJobItem extends JobItem {
     private boolean scheduled;
     private boolean scheduleEnabled;
     private boolean enabled;
-    private boolean serverOwner;
+    private Boolean serverOwner;
 
 
     public String getServerNodeUUID() {
@@ -51,23 +51,31 @@ public class ScheduledJobItem extends JobItem {
         this.enabled = enabled;
     }
 
-    public boolean isServerOwner() {
+    public Boolean isServerOwner() {
         return serverOwner;
     }
 
-    public void setServerOwner(boolean serverOwner) {
+    public void setServerOwner(Boolean serverOwner) {
         this.serverOwner = serverOwner;
     }
 
     public Map<Object, Object> toMap() {
         HashMap<Object, Object> map = new LinkedHashMap<>();
-        map.put("job", toBasicString());
-        map.put("project", getProject());
-        map.put("serverNodeUUID", getServerNodeUUID());
-        map.put("scheduled", scheduled);
-        map.put("scheduleEnabled", scheduleEnabled);
-        map.put("enabled", enabled);
-        map.put("serverOwner", serverOwner);
+
+
+        HashMap<Object, Object> detail = new LinkedHashMap<>(super.toMap());
+        detail.put("scheduled", scheduled);
+        detail.put("scheduleEnabled", scheduleEnabled);
+        detail.put("enabled", enabled);
+
+        map.put("job", detail);
+
+        if (null != serverOwner && null != getServerNodeUUID()) {
+            HashMap<Object, Object> schedule = new LinkedHashMap<>();
+            schedule.put("serverNodeUUID", getServerNodeUUID());
+            schedule.put("serverOwner", serverOwner);
+            map.put("scheduler", schedule);
+        }
         return map;
     }
 

--- a/src/main/java/org/rundeck/client/tool/commands/Jobs.java
+++ b/src/main/java/org/rundeck/client/tool/commands/Jobs.java
@@ -1,6 +1,7 @@
 package org.rundeck.client.tool.commands;
 
 import com.lexicalscope.jewel.cli.CommandLineInterface;
+import com.lexicalscope.jewel.cli.Option;
 import com.simplifyops.toolbelt.Command;
 import com.simplifyops.toolbelt.CommandOutput;
 import okhttp3.RequestBody;
@@ -18,6 +19,7 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Created by greg on 3/28/16.
@@ -180,6 +182,18 @@ public class Jobs extends ApiCommand {
                 output.output("* " + jobItem.toBasicString());
             }
         }
+    }
+
+    @CommandLineInterface(application = "info") interface InfoOpts {
+
+        @Option(shortName = "i", longName = "id", description = "Job ID")
+        String getId();
+    }
+
+    @Command(description = "Get info about a Job by ID (API v18)")
+    public void info(InfoOpts options, CommandOutput output) throws IOException {
+        ScheduledJobItem body = client.checkError(client.getService().getJobInfo(options.getId()));
+        output.output(body.toMap());
     }
 
     /**

--- a/src/main/java/org/rundeck/client/tool/commands/Run.java
+++ b/src/main/java/org/rundeck/client/tool/commands/Run.java
@@ -5,13 +5,17 @@ import com.simplifyops.toolbelt.CommandOutput;
 import org.rundeck.client.api.RundeckApi;
 import org.rundeck.client.api.model.Execution;
 import org.rundeck.client.api.model.JobItem;
+import org.rundeck.client.api.model.JobRun;
 import org.rundeck.client.tool.options.RunBaseOptions;
 import org.rundeck.client.util.Client;
 import org.rundeck.client.util.Quoting;
 import retrofit2.Call;
 
 import java.io.IOException;
+import java.text.ParseException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by greg on 5/20/16.
@@ -56,13 +60,52 @@ public class Run extends ApiCommand {
             throw new IllegalArgumentException("-j job or -i id is required");
 
         }
-        Call<Execution> executionListCall = client.getService().runJob(
-                jobId,
-                Quoting.joinStringQuoted(options.getCommandString()),
-                options.getLoglevel(),
-                options.getFilter(),
-                options.getUser()
-        );
+        Call<Execution> executionListCall;
+        if (client.getApiVersion() >= 18) {
+            JobRun request = new JobRun();
+            request.setLoglevel(options.getLoglevel());
+            request.setFilter(options.getFilter());
+            request.setAsUser(options.getUser());
+            List<String> commandString = options.getCommandString();
+            Map<String, String> jobopts = new HashMap<>();
+            String key = null;
+            if (null != commandString) {
+                for (String s : commandString) {
+                    if (key == null && s.startsWith("-")) {
+                        key = s.substring(1);
+                    } else if (key != null) {
+                        jobopts.put(key, s);
+                        key = null;
+                    }
+                }
+            }
+            if (key != null) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Incorrect job options, expected: \"-%s value\", but saw only \"-%s\"",
+                                key,
+                                key
+                        ));
+            }
+
+            request.setOptions(jobopts);
+            if (null != options.getRunAtDate()) {
+                try {
+                    request.setRunAtTime(options.getRunAtDate().toDate("yyyy-MM-dd'T'HH:mm:ssXX"));
+                } catch (ParseException e) {
+                    throw new IllegalArgumentException("-@/--at date format is not valid", e);
+                }
+            }
+            executionListCall = client.getService().runJob(jobId, request);
+        } else {
+            executionListCall = client.getService().runJob(
+                    jobId,
+                    Quoting.joinStringQuoted(options.getCommandString()),
+                    options.getLoglevel(),
+                    options.getFilter(),
+                    options.getUser()
+            );
+        }
         Execution execution = client.checkError(executionListCall);
         out.output(String.format("Execution started: %s%n", execution.toBasicString()));
 

--- a/src/main/java/org/rundeck/client/tool/options/RunBaseOptions.java
+++ b/src/main/java/org/rundeck/client/tool/options/RunBaseOptions.java
@@ -3,7 +3,9 @@ package org.rundeck.client.tool.options;
 import com.lexicalscope.jewel.cli.CommandLineInterface;
 import com.lexicalscope.jewel.cli.Option;
 import com.lexicalscope.jewel.cli.Unparsed;
+import org.rundeck.client.api.model.DateInfo;
 
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -40,7 +42,14 @@ public interface RunBaseOptions extends FollowOptions,OptionalProjectOptions {
 
     boolean isUser();
 
-    @Unparsed(name = "-- -ARG VAL -ARG2 VAL", description = "Dispatch specified command string")
+    @Option(shortName = "@",
+            longName = "at",
+            description = "Run the job at the specified date/time. ISO8601 format (yyyy-MM-dd'T'HH:mm:ss'Z')")
+    DateInfo getRunAtDate();
+
+    boolean isRunAtDate();
+
+    @Unparsed(name = "-- -OPT VAL -OPT2 VAL", description = "Job options")
     List<String> getCommandString();
 
 }

--- a/src/main/java/org/rundeck/client/util/Client.java
+++ b/src/main/java/org/rundeck/client/util/Client.java
@@ -36,10 +36,12 @@ public class Client<T> {
     public static final String API_ERROR_API_VERSION_UNSUPPORTED = "api.error.api-version.unsupported";
     private T service;
     private Retrofit retrofit;
+    private int apiVersion;
 
-    public Client(final T service, final Retrofit retrofit) {
+    public Client(final T service, final Retrofit retrofit, final int apiVersion) {
         this.service = service;
         this.retrofit = retrofit;
+        this.apiVersion = apiVersion;
     }
 
     /**
@@ -201,5 +203,9 @@ public class Client<T> {
 
     public void setRetrofit(Retrofit retrofit) {
         this.retrofit = retrofit;
+    }
+
+    public int getApiVersion() {
+        return apiVersion;
     }
 }


### PR DESCRIPTION
When RUNDECK_URL is using `/api/18`:

* job info endpoint `rd jobs info -i ID`
* job runAtTime  `rd run -i ID -@ <time> -- -opt1 val1 -opt2 val2` 

~~~
-@/--at Run the job at the specified date/time. ISO8601 format (yyyy-MM-dd'T'HH:mm:ss'Z')
~~~