### PR TITLE
Formatting improvements:

### DIFF
--- a/src/main/java/org/rundeck/client/api/model/Execution.java
+++ b/src/main/java/org/rundeck/client/api/model/Execution.java
@@ -40,13 +40,23 @@ public class Execution {
         }
         return String.format("[%s] <%s>", id, permalink);
     }
-    public String toExtendedString() throws ParseException {
+
+    public String toExtendedString() {
         if(null!=dateEnded) {
-            return String.format("[%s] %s: %s, %s <%s>", id, status, dateEnded.toRelative(),
-                                 getBasicDescription(), permalink
-            );
+            try {
+                return String.format(
+                        "%s %s %s %s %s",
+                        id,
+                        status,
+                        dateEnded.toDate(),
+                        getBasicDescription(),
+                        permalink
+                );
+            } catch (ParseException e) {
+                return toBasicString();
+            }
         }
-        return String.format("[%s] <%s>", id, permalink);
+        return String.format("%s %s", id, permalink);
     }
 
     private String getBasicDescription() {

--- a/src/main/java/org/rundeck/client/api/model/JobItem.java
+++ b/src/main/java/org/rundeck/client/api/model/JobItem.java
@@ -1,6 +1,7 @@
 package org.rundeck.client.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.rundeck.client.util.Format;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.Root;
@@ -8,6 +9,8 @@ import org.simpleframework.xml.Root;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Created by greg on 3/28/16.
@@ -105,8 +108,13 @@ public class JobItem {
         HashMap<Object, Object> map = new LinkedHashMap<>();
         map.put("id", getId());
         map.put("name", getName());
-        map.put("group", getGroup());
+        if (null != getGroup()) {
+            map.put("group", getGroup());
+        }
         map.put("project", getProject());
+        map.put("href", getHref());
+        map.put("permalink", getPermalink());
+        map.put("description", getDescription());
         if(null!=getAverageDuration()){
             map.put("averageDuration", getAverageDuration());
         }
@@ -114,7 +122,7 @@ public class JobItem {
     }
 
     public String toBasicString() {
-        return String.format("[%s] %s%s", id, group != null ? group + "/" : "", name);
+        return String.format("%s %s%s", id, group != null ? group + "/" : "", name);
     }
 
     public Long getAverageDuration() {

--- a/src/main/java/org/rundeck/client/tool/options/ExecutionOutputFormatOption.java
+++ b/src/main/java/org/rundeck/client/tool/options/ExecutionOutputFormatOption.java
@@ -1,0 +1,18 @@
+package org.rundeck.client.tool.options;
+
+import com.lexicalscope.jewel.cli.Option;
+
+/**
+ * Created by greg on 11/17/16.
+ */
+public interface ExecutionOutputFormatOption {
+
+    @Option(shortName = "%",
+            longName = "outformat",
+            description = "Output format specifier for execution data. You can use \"%key\" where key is one of:" +
+                          "id, project, description, argstring, permalink, href, status, job, user, serverUUID, " +
+                          "dateStarted, dateEnded, successfulNodes, failedNodes. E.g. \"%id %href\"")
+    String getOutputFormat();
+
+    boolean isOutputFormat();
+}

--- a/src/main/java/org/rundeck/client/tool/options/JobOutputFormatOption.java
+++ b/src/main/java/org/rundeck/client/tool/options/JobOutputFormatOption.java
@@ -1,0 +1,17 @@
+package org.rundeck.client.tool.options;
+
+import com.lexicalscope.jewel.cli.Option;
+
+/**
+ * Created by greg on 11/17/16.
+ */
+public interface JobOutputFormatOption {
+
+    @Option(shortName = "%",
+            longName = "outformat",
+            description = "Output format specifier for job data. You can use \"%key\" where key is one of:" +
+                          "id, name, group, project, description, href, permalink, averageDuration. E.g. \"%id %href\"")
+    String getOutputFormat();
+
+    boolean isOutputFormat();
+}

--- a/src/main/java/org/rundeck/client/tool/options/VerboseOption.java
+++ b/src/main/java/org/rundeck/client/tool/options/VerboseOption.java
@@ -1,0 +1,13 @@
+package org.rundeck.client.tool.options;
+
+import com.lexicalscope.jewel.cli.Option;
+
+/**
+ * Created by greg on 11/17/16.
+ */
+public interface VerboseOption {
+
+    @Option(shortName = "v", longName = "verbose", description = "Extended verbose output")
+    boolean isVerbose();
+
+}

--- a/src/main/java/org/rundeck/client/util/Format.java
+++ b/src/main/java/org/rundeck/client/util/Format.java
@@ -1,0 +1,39 @@
+package org.rundeck.client.util;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Created by greg on 11/17/16.
+ */
+public class Format {
+    public static String format(String format, Map<?, ?> data, final String start, final String end) {
+        Pattern pat = Pattern.compile(Pattern.quote(start) + "(\\w+)" + Pattern.quote(end));
+        Matcher matcher = pat.matcher(format);
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            String found = matcher.group(1);
+            Object result = data.containsKey(found) ? data.get(found) : null;
+            matcher.appendReplacement(sb, result != null ? result.toString() : "");
+        }
+        matcher.appendTail(sb);
+
+        return sb.toString();
+    }
+
+    public static Function<Map<?, ?>, String> formatter(String format, final String start, final String end) {
+        return (Map<?, ?> map) -> format(format, map, start, end);
+    }
+
+    public static <X> Function<X, String> formatter(
+            String format,
+            Function<X, Map<?, ?>> convert,
+            final String start,
+            final String end
+    )
+    {
+        return (X obj) -> format(format, convert.apply(obj), start, end);
+    }
+}

--- a/src/test/groovy/org/rundeck/client/util/FormatSpec.groovy
+++ b/src/test/groovy/org/rundeck/client/util/FormatSpec.groovy
@@ -1,0 +1,24 @@
+package org.rundeck.client.util
+
+import spock.lang.Specification
+
+/**
+ * Created by greg on 11/17/16.
+ */
+class FormatSpec extends Specification {
+    def "format"() {
+        given:
+        when:
+        def result = Format.format(format, data, start, end)
+        then:
+        result == expected
+        where:
+        start | end | format        | data     | expected
+        '${'  | '}' | '${a} b c'    | [a: 'x'] | 'x b c'
+        '${'  | '}' | 'a ${b} c'    | [a: 'x'] | 'a  c'
+        '${'  | '}' | 'a ${b} c'    | [b: 'x'] | 'a x c'
+        '${'  | '}' | 'a ${b} ${c}' | [b: 'x'] | 'a x '
+        '%'   | ''  | 'a %b %c'     | [b: 'x'] | 'a x '
+
+    }
+}


### PR DESCRIPTION
* simplified default format for execution/job listing
* add `-%/--outformat` flag for execution/job listing, specifying
  output format in the form "%id %name" etc.  When used, only the data
  while be echoed
* add `-v/--verbose` to job/execution list, showing all data fields