### PR TITLE
Handle chars "$" and "\" in job output if formatter is used

### DIFF
--- a/src/main/java/org/rundeck/client/util/Format.java
+++ b/src/main/java/org/rundeck/client/util/Format.java
@@ -41,7 +41,11 @@ public class Format {
                 path = found.split("\\.");
             }
             Object result = descend(data, path);
-            matcher.appendReplacement(sb, result != null ? result.toString() : "");
+            String replacement = "";
+            if (result != null) {
+                replacement = Matcher.quoteReplacement(result.toString());
+            }
+            matcher.appendReplacement(sb, replacement);
         }
         matcher.appendTail(sb);
 

--- a/src/test/groovy/org/rundeck/client/util/FormatSpec.groovy
+++ b/src/test/groovy/org/rundeck/client/util/FormatSpec.groovy
@@ -29,12 +29,14 @@ class FormatSpec extends Specification {
         then:
         result == expected
         where:
-        start | end | format        | data     | expected
-        '${'  | '}' | '${a} b c'    | [a: 'x'] | 'x b c'
-        '${'  | '}' | 'a ${b} c'    | [a: 'x'] | 'a  c'
-        '${'  | '}' | 'a ${b} c'    | [b: 'x'] | 'a x c'
-        '${'  | '}' | 'a ${b} ${c}' | [b: 'x'] | 'a x '
-        '%'   | ''  | 'a %b %c'     | [b: 'x'] | 'a x '
+        start | end | format        | data       | expected
+        '${'  | '}' | '${a} b c'    | [a: 'x']   | 'x b c'
+        '${'  | '}' | 'a ${b} c'    | [a: 'x']   | 'a  c'
+        '${'  | '}' | 'a ${b} c'    | [b: 'x']   | 'a x c'
+        '${'  | '}' | 'a ${b} ${c}' | [b: 'x']   | 'a x '
+        '%'   | ''  | 'a %b %c'     | [b: 'x']   | 'a x '
+        '%'   | ''  | 'a %b %c'     | [b: '$x']  | 'a $x '
+        '%'   | ''  | 'a %b %c'     | [b: '\\x'] | 'a \\x '
 
     }
 


### PR DESCRIPTION
If the output of a command contains the chars "$" or "\" and the
formatter is used, the characters "$" and "\" are not handled. Hence,
an exception is thrown:
java.lang.IllegalArgumentException: Illegal group reference
	at java.util.regex.Matcher.appendReplacement(Matcher.java:857)
	at org.rundeck.client.util.Format.format(Format.java:44)

### Steps to reproduce
1. Create a job "mytestjob", which executes the inline script `echo '$some-test$'`
2. Execute the job via cli command: `rd run --outformat '%node: %log' --job 'mytestjob' --follow`

### Actual result (without this fix)
> java.lang.IllegalArgumentException: Illegal group reference
	at java.util.regex.Matcher.appendReplacement(Matcher.java:857)
	at org.rundeck.client.util.Format.format(Format.java:44)

### Expected result
no exception, just the output:
> $some-test$
