### PR TITLE
Add API version downgrading, update API version to 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 
-ext.toolbeltVersion = "0.1.19"
+ext.toolbeltVersion = "0.1.20"
 ext.toolbeltGroup =  "com${toolbeltVersion.contains('SNAPSHOT')?'':'.github'}.simplifyops.cli-toolbelt"
 
 dependencies {

--- a/src/main/java/org/rundeck/client/RundeckClient.java
+++ b/src/main/java/org/rundeck/client/RundeckClient.java
@@ -35,9 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.rundeck.client.tool.Main.ENV_CONNECT_RETRY;
-import static org.rundeck.client.tool.Main.ENV_DEBUG;
-import static org.rundeck.client.tool.Main.ENV_HTTP_TIMEOUT;
+import static org.rundeck.client.tool.Main.*;
 
 /**
  * Build a {@link Client} for {@link RundeckApi} using {@link #builder()}.
@@ -55,6 +53,7 @@ public class RundeckClient {
     private RundeckClient() {
     }
 
+
     @SuppressWarnings("UnusedReturnValue")
     public static class Builder {
         final OkHttpClient.Builder okhttp;
@@ -62,6 +61,9 @@ public class RundeckClient {
         String appBaseUrl;
         int httpLogging;
         HttpUrl parseUrl;
+        Integer apiVersion;
+        boolean allowVersionDowngrade;
+        Client.Logger logger;
 
         Builder() {
             this.okhttp = new OkHttpClient.Builder();
@@ -73,13 +75,14 @@ public class RundeckClient {
         }
 
         public Builder config(AppConfig config) {
-            logging(config.getInt(ENV_DEBUG, 0));
+            logging(config.getDebugLevel());
             retryConnect(config.getBool(ENV_CONNECT_RETRY, true));
             timeout(config.getLong(ENV_HTTP_TIMEOUT, null));
             bypassUrl(config.getString(ENV_BYPASS_URL, null));
             insecureSSL(config.getBool(ENV_INSECURE_SSL, false));
             insecureSSLHostname(config.getBool(ENV_INSECURE_SSL_HOSTNAME, false));
             alternateSSLHostname(config.getString(ENV_ALT_SSL_HOSTNAME, null));
+            allowVersionDowngrade(config.getBool(RD_API_DOWNGRADE, false));
             return this;
         }
 
@@ -115,6 +118,16 @@ public class RundeckClient {
             return this;
         }
 
+        public Builder apiVersion(final int version) {
+            this.apiVersion = version;
+            return this;
+        }
+
+        public Builder allowVersionDowngrade(final boolean allow) {
+            this.allowVersionDowngrade = allow;
+            return this;
+        }
+
         public Builder tokenAuth(final String authToken) {
             buildTokenAuth(okhttp, baseUrl, authToken);
             return this;
@@ -126,12 +139,17 @@ public class RundeckClient {
         }
 
         public Client<RundeckApi> build() {
-            return buildRundeckClient(okhttp, baseUrl, API_VERS);
+            return buildRundeckClient();
         }
 
         public Builder logging(final int p) {
             httpLogging = p;
             return accept(RundeckClient::configLogging, p);
+        }
+
+        public Builder logger(Client.Logger logger) {
+            this.logger = logger;
+            return this;
         }
 
         private static void buildTokenAuth(
@@ -196,21 +214,26 @@ public class RundeckClient {
 
         }
 
-        private static Client<RundeckApi> buildRundeckClient(
-                final OkHttpClient.Builder builder,
-                final String baseUrl,
-                final int apiVers
-        )
-        {
-            String apiBaseUrl = buildApiUrlForVersion(baseUrl, apiVers);
-            int usedApiVers = apiVersionForUrl(baseUrl, apiVers);
+        private Client<RundeckApi> buildRundeckClient() {
+            //url without version
+            String appBaseUrl = buildBaseAppUrlForVersion(baseUrl);
+            final String apiBaseUrl;
+            if (null != apiVersion) {
+                //construct api url using requested version
+                apiBaseUrl = buildApiUrlForVersion(appBaseUrl, apiVersion);
+            } else {
+                //if url has no version, use default
+                apiBaseUrl = buildApiUrlForVersion(baseUrl, API_VERS);
+            }
+            //detected final version
+            int usedApiVers = apiVersionForUrl(apiBaseUrl, API_VERS);
 
-            builder.addInterceptor(new StaticHeaderInterceptor("User-Agent", USER_AGENT));
+            okhttp.addInterceptor(new StaticHeaderInterceptor("User-Agent", USER_AGENT));
 
 
             Retrofit build = new Retrofit.Builder()
                     .baseUrl(apiBaseUrl)
-                    .client(builder.build())
+                    .client(okhttp.build())
                     .addConverterFactory(new QualifiedTypeConverterFactory(
                             JacksonConverterFactory.create(),
                             SimpleXmlConverterFactory.create(),
@@ -218,7 +241,15 @@ public class RundeckClient {
                     ))
                     .build();
 
-            return new Client<>(build.create(RundeckApi.class), build, usedApiVers);
+            return new Client<>(
+                    build.create(RundeckApi.class),
+                    build,
+                    appBaseUrl,
+                    apiBaseUrl,
+                    usedApiVers,
+                    allowVersionDowngrade,
+                    logger
+            );
         }
 
         private static void validateNotempty(final String authToken, final String s) {
@@ -384,6 +415,13 @@ public class RundeckClient {
     }
 
 
+    /**
+     * Normalize a url by appending a / if not present
+     *
+     * @param baseUrl
+     *
+     * @return
+     */
     private static String normalizeUrlPath(String baseUrl) {
         if (!baseUrl.matches(".*/$")) {
             return baseUrl + "/";

--- a/src/main/java/org/rundeck/client/RundeckClient.java
+++ b/src/main/java/org/rundeck/client/RundeckClient.java
@@ -44,7 +44,7 @@ import static org.rundeck.client.tool.Main.ENV_HTTP_TIMEOUT;
  */
 public class RundeckClient {
     public static final String USER_AGENT = Version.NAME + "/" + Version.VERSION;
-    public static final int API_VERS = 18;
+    public static final int API_VERS = 21;
     public static final Pattern API_VERS_PATTERN = Pattern.compile("^(.*)(/api/(\\d+)/?)$");
     public static final String ENV_BYPASS_URL = "RD_BYPASS_URL";
     public static final String ENV_INSECURE_SSL = "RD_INSECURE_SSL";

--- a/src/main/java/org/rundeck/client/api/RequestFailed.java
+++ b/src/main/java/org/rundeck/client/api/RequestFailed.java
@@ -20,8 +20,8 @@ package org.rundeck.client.api;
  * Http request failure
  */
 public class RequestFailed extends RuntimeException {
-    final int statusCode;
-    final String status;
+    private final int statusCode;
+    private final String status;
 
     public RequestFailed(final int statusCode, final String status) {
         this.statusCode = statusCode;
@@ -44,5 +44,13 @@ public class RequestFailed extends RuntimeException {
         super(cause);
         this.statusCode = statusCode;
         this.status = status;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getStatus() {
+        return status;
     }
 }

--- a/src/main/java/org/rundeck/client/api/model/ErrorResponse.java
+++ b/src/main/java/org/rundeck/client/api/model/ErrorResponse.java
@@ -73,7 +73,7 @@ public class ErrorResponse implements ErrorDetail {
     @Override
     public String toString() {
         return String.format(
-                "%s%n%s%n",
+                "%s%n%s",
                 getErrorMessage() != null ? getErrorMessage() : "(no message)",
                 toCodeString()
         );

--- a/src/main/java/org/rundeck/client/tool/AppConfig.java
+++ b/src/main/java/org/rundeck/client/tool/AppConfig.java
@@ -24,6 +24,7 @@ import org.rundeck.client.util.ConfigSource;
  */
 public interface AppConfig extends ConfigSource {
     boolean isAnsiEnabled();
+    int getDebugLevel();
 
     String getDateFormat();
 }

--- a/src/main/java/org/rundeck/client/tool/RdApp.java
+++ b/src/main/java/org/rundeck/client/tool/RdApp.java
@@ -24,17 +24,41 @@ import org.rundeck.client.util.Client;
 import org.rundeck.client.util.ServiceClient;
 
 /**
+ * Access to config, output, and service client
  * @author greg
  * @since 1/11/17
  */
 public interface RdApp {
+    /**
+     * @return current service client
+     *
+     * @throws InputError on error
+     */
     ServiceClient<RundeckApi> getClient() throws InputError;
 
+    /**
+     * @param version api version to use
+     *
+     * @return service client for particular api version
+     *
+     * @throws InputError on erro
+     */
     ServiceClient<RundeckApi> getClient(int version) throws InputError;
 
+    /**
+     * @return app config
+     */
     AppConfig getAppConfig();
 
+    /**
+     * @return output endpoint
+     */
     public CommandOutput getOutput();
 
+    /**
+     * Issue warning about api version downgrade
+     * @param requested requested api version
+     * @param supported supported api verson
+     */
     public void versionDowngradeWarning(int requested, int supported);
 }

--- a/src/main/java/org/rundeck/client/tool/RdApp.java
+++ b/src/main/java/org/rundeck/client/tool/RdApp.java
@@ -21,15 +21,16 @@ import com.simplifyops.toolbelt.InputError;
 import org.rundeck.client.api.RundeckApi;
 import org.rundeck.client.tool.AppConfig;
 import org.rundeck.client.util.Client;
+import org.rundeck.client.util.ServiceClient;
 
 /**
  * @author greg
  * @since 1/11/17
  */
 public interface RdApp {
-    Client<RundeckApi> getClient() throws InputError;
+    ServiceClient<RundeckApi> getClient() throws InputError;
 
-    Client<RundeckApi> getClient(int version) throws InputError;
+    ServiceClient<RundeckApi> getClient(int version) throws InputError;
 
     AppConfig getAppConfig();
 

--- a/src/main/java/org/rundeck/client/tool/RdApp.java
+++ b/src/main/java/org/rundeck/client/tool/RdApp.java
@@ -16,6 +16,7 @@
 
 package org.rundeck.client.tool;
 
+import com.simplifyops.toolbelt.CommandOutput;
 import com.simplifyops.toolbelt.InputError;
 import org.rundeck.client.api.RundeckApi;
 import org.rundeck.client.tool.AppConfig;
@@ -28,5 +29,11 @@ import org.rundeck.client.util.Client;
 public interface RdApp {
     Client<RundeckApi> getClient() throws InputError;
 
+    Client<RundeckApi> getClient(int version) throws InputError;
+
     AppConfig getAppConfig();
+
+    public CommandOutput getOutput();
+
+    public void versionDowngradeWarning(int requested, int supported);
 }

--- a/src/main/java/org/rundeck/client/tool/commands/AppCommand.java
+++ b/src/main/java/org/rundeck/client/tool/commands/AppCommand.java
@@ -23,6 +23,7 @@ import org.rundeck.client.tool.AppConfig;
 import org.rundeck.client.tool.RdApp;
 import org.rundeck.client.tool.options.ProjectNameOptions;
 import org.rundeck.client.util.Client;
+import org.rundeck.client.util.ServiceClient;
 import retrofit2.Call;
 
 import java.io.IOException;
@@ -35,7 +36,7 @@ public abstract class AppCommand implements RdApp {
         this.rdApp = rdApp;
     }
 
-    public Client<RundeckApi> getClient() throws InputError {
+    public ServiceClient<RundeckApi> getClient() throws InputError {
         return rdApp.getClient();
     }
 
@@ -49,7 +50,7 @@ public abstract class AppCommand implements RdApp {
     }
 
     @Override
-    public Client<RundeckApi> getClient(final int version) throws InputError {
+    public ServiceClient<RundeckApi> getClient(final int version) throws InputError {
         return rdApp.getClient(version);
     }
 
@@ -76,7 +77,7 @@ public abstract class AppCommand implements RdApp {
     }
 
     public static <T> T apiCall(
-            final Client<RundeckApi> client,
+            final ServiceClient<RundeckApi> client,
             final Function<RundeckApi, Call<T>> func
     )
             throws IOException
@@ -85,7 +86,7 @@ public abstract class AppCommand implements RdApp {
     }
 
     public static <T> T apiCallDowngradable(
-            final Client<RundeckApi> client,
+            final ServiceClient<RundeckApi> client,
             final Function<RundeckApi, Call<T>> func
     )
             throws IOException, Client.UnsupportedVersion

--- a/src/main/java/org/rundeck/client/tool/commands/Jobs.java
+++ b/src/main/java/org/rundeck/client/tool/commands/Jobs.java
@@ -31,6 +31,7 @@ import org.rundeck.client.tool.commands.jobs.Files;
 import org.rundeck.client.tool.options.*;
 import org.rundeck.client.util.Client;
 import org.rundeck.client.util.Format;
+import org.rundeck.client.util.ServiceClient;
 import org.rundeck.client.util.Util;
 import retrofit2.Call;
 
@@ -215,8 +216,8 @@ public class Jobs extends AppCommand implements HasSubCommands {
             }
             ResponseBody body = getClient().checkError(responseCall);
             if ((!"yaml".equals(options.getFormat()) ||
-                 !Client.hasAnyMediaType(body, Client.MEDIA_TYPE_YAML, Client.MEDIA_TYPE_TEXT_YAML)) &&
-                !Client.hasAnyMediaType(body, Client.MEDIA_TYPE_XML, Client.MEDIA_TYPE_TEXT_XML)) {
+                 !ServiceClient.hasAnyMediaType(body, Client.MEDIA_TYPE_YAML, Client.MEDIA_TYPE_TEXT_YAML)) &&
+                !ServiceClient.hasAnyMediaType(body, Client.MEDIA_TYPE_XML, Client.MEDIA_TYPE_TEXT_XML)) {
 
                 throw new IllegalStateException("Unexpected response format: " + body.contentType());
             }

--- a/src/main/java/org/rundeck/client/tool/commands/Jobs.java
+++ b/src/main/java/org/rundeck/client/tool/commands/Jobs.java
@@ -65,7 +65,7 @@ public class Jobs extends AppCommand implements HasSubCommands {
     @Override
     public List<Object> getSubCommands() {
         return Collections.singletonList(
-                new Files(this)
+                new Files(getRdApp())
         );
     }
 
@@ -344,7 +344,7 @@ public class Jobs extends AppCommand implements HasSubCommands {
         String jobId = Run.getJobIdFromOpts(
                 options,
                 output,
-                getClient(),
+                getRdApp(),
                 () -> projectOrEnv(options)
         );
         if (null == jobId) {

--- a/src/main/java/org/rundeck/client/tool/commands/Keys.java
+++ b/src/main/java/org/rundeck/client/tool/commands/Keys.java
@@ -28,6 +28,7 @@ import okhttp3.ResponseBody;
 import org.rundeck.client.api.model.KeyStorageItem;
 import org.rundeck.client.tool.RdApp;
 import org.rundeck.client.util.Client;
+import org.rundeck.client.util.ServiceClient;
 import org.rundeck.client.util.Util;
 
 import java.io.*;
@@ -174,7 +175,7 @@ public class Keys extends AppCommand {
             return false;
         }
         ResponseBody body = apiCall(api -> api.getPublicKey(path.keysPath()));
-        if (!Client.hasAnyMediaType(body, Client.MEDIA_TYPE_GPG_KEYS)) {
+        if (!ServiceClient.hasAnyMediaType(body, Client.MEDIA_TYPE_GPG_KEYS)) {
             throw new IllegalStateException("Unexpected response format: " + body.contentType());
         }
         InputStream inputStream = body.byteStream();

--- a/src/main/java/org/rundeck/client/tool/commands/Projects.java
+++ b/src/main/java/org/rundeck/client/tool/commands/Projects.java
@@ -50,11 +50,11 @@ public class Projects extends AppCommand implements HasSubCommands {
     @Override
     public List<Object> getSubCommands() {
         return Arrays.asList(
-                new ACLs(this),
-                new SCM(this),
-                new Readme(this),
-                new Configure(this),
-                new Archives(this)
+                new ACLs(getRdApp()),
+                new SCM(getRdApp()),
+                new Readme(getRdApp()),
+                new Configure(getRdApp()),
+                new Archives(getRdApp())
         );
     }
 

--- a/src/main/java/org/rundeck/client/tool/commands/RDSystem.java
+++ b/src/main/java/org/rundeck/client/tool/commands/RDSystem.java
@@ -43,8 +43,8 @@ public class RDSystem extends AppCommand implements HasSubCommands {
     @Override
     public List<Object> getSubCommands() {
         return Arrays.asList(
-                new ACLs(this),
-                new Mode(this)
+                new ACLs(getRdApp()),
+                new Mode(getRdApp())
         );
     }
 

--- a/src/main/java/org/rundeck/client/tool/commands/Run.java
+++ b/src/main/java/org/rundeck/client/tool/commands/Run.java
@@ -31,6 +31,7 @@ import org.rundeck.client.tool.options.RunBaseOptions;
 import org.rundeck.client.util.Client;
 import org.rundeck.client.util.Format;
 import org.rundeck.client.util.Quoting;
+import org.rundeck.client.util.ServiceClient;
 import retrofit2.Call;
 
 import java.io.File;
@@ -200,7 +201,7 @@ public class Run extends AppCommand {
     public static String getJobIdFromOpts(
             final JobIdentOptions options,
             final CommandOutput out,
-            final Client<RundeckApi> client,
+            final ServiceClient<RundeckApi> client,
             final GetInput<String> project
     )
             throws InputError, IOException

--- a/src/main/java/org/rundeck/client/tool/commands/Run.java
+++ b/src/main/java/org/rundeck/client/tool/commands/Run.java
@@ -28,7 +28,6 @@ import org.rundeck.client.tool.RdApp;
 import org.rundeck.client.tool.commands.jobs.Files;
 import org.rundeck.client.tool.options.JobIdentOptions;
 import org.rundeck.client.tool.options.RunBaseOptions;
-import org.rundeck.client.util.Client;
 import org.rundeck.client.util.Format;
 import org.rundeck.client.util.Quoting;
 import org.rundeck.client.util.ServiceClient;
@@ -61,7 +60,7 @@ public class Run extends AppCommand {
 
     @Command(isDefault = true, isSolo = true)
     public boolean run(RunBaseOptions options, CommandOutput out) throws IOException, InputError {
-        String jobId = getJobIdFromOpts(options, out, getClient(), () -> projectOrEnv(options));
+        String jobId = getJobIdFromOpts(options, out, getRdApp(), () -> projectOrEnv(options));
         if (null == jobId) {
             return false;
         }
@@ -127,7 +126,7 @@ public class Run extends AppCommand {
                 for (String optionName : fileinputs.keySet()) {
                     File file = fileinputs.get(optionName);
                     JobFileUploadResult jobFileUploadResult = Files.uploadFileForJob(
-                            getClient(),
+                            getRdApp(),
                             file,
                             jobId,
                             optionName
@@ -192,7 +191,7 @@ public class Run extends AppCommand {
      *
      * @param options ident options
      * @param out     output
-     * @param client  client
+     * @param rdApp  rdApp
      * @param project project name, or null
      *
      * @return job ID or null
@@ -201,7 +200,7 @@ public class Run extends AppCommand {
     public static String getJobIdFromOpts(
             final JobIdentOptions options,
             final CommandOutput out,
-            final ServiceClient<RundeckApi> client,
+            final RdApp rdApp,
             final GetInput<String> project
     )
             throws InputError, IOException
@@ -215,7 +214,7 @@ public class Run extends AppCommand {
         String proj = project.get();
         String job = options.getJob();
         String[] parts = Jobs.splitJobNameParts(job);
-        List<JobItem> jobItems = apiCall(client, api -> api.listJobs(
+        List<JobItem> jobItems = apiCallDowngradable(rdApp, api -> api.listJobs(
                 proj,
                 null,
                 null,

--- a/src/main/java/org/rundeck/client/tool/commands/jobs/Files.java
+++ b/src/main/java/org/rundeck/client/tool/commands/jobs/Files.java
@@ -31,6 +31,7 @@ import org.rundeck.client.tool.RdApp;
 import org.rundeck.client.tool.commands.AppCommand;
 import org.rundeck.client.tool.options.PagingResultOptions;
 import org.rundeck.client.util.Client;
+import org.rundeck.client.util.ServiceClient;
 
 import java.io.File;
 import java.io.IOException;
@@ -174,7 +175,7 @@ public class Files extends AppCommand {
      *
      */
     public static JobFileUploadResult uploadFileForJob(
-            final Client<RundeckApi> client,
+            final ServiceClient<RundeckApi> client,
             final File input,
             final String jobId,
             final String optionName

--- a/src/main/java/org/rundeck/client/tool/commands/jobs/Files.java
+++ b/src/main/java/org/rundeck/client/tool/commands/jobs/Files.java
@@ -22,7 +22,6 @@ import com.simplifyops.toolbelt.Command;
 import com.simplifyops.toolbelt.CommandOutput;
 import com.simplifyops.toolbelt.InputError;
 import okhttp3.RequestBody;
-import org.rundeck.client.api.RundeckApi;
 import org.rundeck.client.api.model.JobFileItem;
 import org.rundeck.client.api.model.JobFileItemList;
 import org.rundeck.client.api.model.JobFileUploadResult;
@@ -31,7 +30,6 @@ import org.rundeck.client.tool.RdApp;
 import org.rundeck.client.tool.commands.AppCommand;
 import org.rundeck.client.tool.options.PagingResultOptions;
 import org.rundeck.client.util.Client;
-import org.rundeck.client.util.ServiceClient;
 
 import java.io.File;
 import java.io.IOException;
@@ -151,7 +149,7 @@ public class Files extends AppCommand {
 
         String fileName = input.getName();
         JobFileUploadResult jobFileUploadResult = uploadFileForJob(
-                getClient(),
+                getRdApp(),
                 input,
                 options.getId(),
                 options.getOption()
@@ -175,18 +173,18 @@ public class Files extends AppCommand {
      *
      */
     public static JobFileUploadResult uploadFileForJob(
-            final ServiceClient<RundeckApi> client,
+            final RdApp rdApp,
             final File input,
             final String jobId,
             final String optionName
-    ) throws IOException
+    ) throws IOException, InputError
     {
         if (invalidInputFile(input)) {
             throw new IOException("Can't read file: " + input);
         }
         RequestBody requestBody = RequestBody.create(Client.MEDIA_TYPE_OCTET_STREAM, input);
-        return apiCall(
-                client,
+        return apiCallDowngradable(
+                rdApp,
                 api -> api.uploadJobOptionFile(
                         jobId,
                         optionName,

--- a/src/main/java/org/rundeck/client/tool/commands/projects/ACLs.java
+++ b/src/main/java/org/rundeck/client/tool/commands/projects/ACLs.java
@@ -35,6 +35,7 @@ import org.rundeck.client.tool.options.ProjectNameOptions;
 import org.rundeck.client.util.Client;
 import org.rundeck.client.util.Colorz;
 import org.rundeck.client.util.Format;
+import org.rundeck.client.util.ServiceClient;
 import retrofit2.Call;
 import retrofit2.Response;
 
@@ -117,7 +118,7 @@ public class ACLs extends AppCommand {
 
     @Command(description = "Upload a project ACL definition")
     public void upload(Put options, CommandOutput output) throws IOException, InputError {
-        Client<RundeckApi> client = getClient();
+        ServiceClient<RundeckApi> client = getClient();
         String project = projectOrEnv(options);
         ACLPolicy aclPolicy = performACLModify(
                 options,
@@ -138,7 +139,7 @@ public class ACLs extends AppCommand {
     @Command(description = "Create a project ACL definition")
     public void create(Create options, CommandOutput output) throws IOException, InputError {
 
-        Client<RundeckApi> client = getClient();
+        ServiceClient<RundeckApi> client = getClient();
         String project = projectOrEnv(options);
         ACLPolicy aclPolicy = performACLModify(
                 options,
@@ -163,7 +164,7 @@ public class ACLs extends AppCommand {
     public static ACLPolicy performACLModify(
             final ACLFileOptions options,
             Function<RequestBody, Call<ACLPolicy>> func,
-            final Client<RundeckApi> client,
+            final ServiceClient<RundeckApi> client,
             final CommandOutput output
     )
             throws IOException, InputError
@@ -186,7 +187,7 @@ public class ACLs extends AppCommand {
 
     private static void checkValidationError(
             CommandOutput output,
-            final Client<RundeckApi> client,
+            final ServiceClient<RundeckApi> client,
             final Response<ACLPolicy> response, final String filename
     )
             throws IOException

--- a/src/main/java/org/rundeck/client/tool/commands/projects/Archives.java
+++ b/src/main/java/org/rundeck/client/tool/commands/projects/Archives.java
@@ -30,6 +30,7 @@ import org.rundeck.client.tool.RdApp;
 import org.rundeck.client.tool.commands.AppCommand;
 import org.rundeck.client.tool.options.ProjectNameOptions;
 import org.rundeck.client.util.Client;
+import org.rundeck.client.util.ServiceClient;
 import org.rundeck.client.util.Util;
 
 import java.io.File;
@@ -231,7 +232,7 @@ public class Archives extends AppCommand {
     }
 
     public static boolean loopStatus(
-            final Client<RundeckApi> client,
+            final ServiceClient<RundeckApi> client,
             final ProjectExportStatus status,
             String project,
             File outputfile,
@@ -269,7 +270,7 @@ public class Archives extends AppCommand {
     )
             throws IOException
     {
-        if (!Client.hasAnyMediaType(responseBody, Client.MEDIA_TYPE_ZIP)) {
+        if (!ServiceClient.hasAnyMediaType(responseBody, Client.MEDIA_TYPE_ZIP)) {
             throw new IllegalStateException("Unexpected response format: " + responseBody.contentType());
         }
         InputStream inputStream = responseBody.byteStream();

--- a/src/main/java/org/rundeck/client/tool/commands/projects/SCM.java
+++ b/src/main/java/org/rundeck/client/tool/commands/projects/SCM.java
@@ -33,6 +33,7 @@ import org.rundeck.client.tool.options.OptionUtil;
 import org.rundeck.client.tool.options.ProjectNameOptions;
 import org.rundeck.client.util.Client;
 import org.rundeck.client.util.Colorz;
+import org.rundeck.client.util.ServiceClient;
 import retrofit2.Response;
 
 import java.io.File;
@@ -342,7 +343,7 @@ public class SCM extends AppCommand {
      */
     private static boolean hasValidationError(
             CommandOutput output,
-            final Client<RundeckApi> client,
+            final ServiceClient<RundeckApi> serviceClient,
             final Response<ScmActionResult> response,
             final String name
     )
@@ -351,7 +352,7 @@ public class SCM extends AppCommand {
             if (response.code() == 400) {
                 try {
                     //parse body as ScmActionResult
-                    ScmActionResult error = client.readError(
+                    ScmActionResult error = serviceClient.readError(
                             response,
                             ScmActionResult.class,
                             Client.MEDIA_TYPE_JSON

--- a/src/main/java/org/rundeck/client/tool/commands/system/ACLs.java
+++ b/src/main/java/org/rundeck/client/tool/commands/system/ACLs.java
@@ -30,6 +30,7 @@ import org.rundeck.client.tool.commands.projects.ACLFileOptions;
 import org.rundeck.client.tool.commands.projects.ACLNameOptions;
 import org.rundeck.client.tool.options.ACLOutputOptions;
 import org.rundeck.client.util.Client;
+import org.rundeck.client.util.ServiceClient;
 
 import java.io.IOException;
 
@@ -72,7 +73,7 @@ public class ACLs extends AppCommand {
             throws IOException, InputError
     {
 
-        Client<RundeckApi> client = getClient();
+        ServiceClient<RundeckApi> client = getClient();
         ACLPolicy aclPolicy = performACLModify(
                 options,
                 (RequestBody body) -> client.getService()
@@ -90,7 +91,7 @@ public class ACLs extends AppCommand {
     @Command(description = "Create a system ACL definition")
     public void create(Create options, CommandOutput output) throws IOException, InputError {
 
-        Client<RundeckApi> client = getClient();
+        ServiceClient<RundeckApi> client = getClient();
         ACLPolicy aclPolicy = performACLModify(
                 options,
                 (RequestBody body) -> client.getService()
@@ -107,7 +108,7 @@ public class ACLs extends AppCommand {
 
     @Command(description = "Delete a system ACL definition")
     public void delete(Delete options, CommandOutput output) throws IOException, InputError {
-        Client<RundeckApi> client = getClient();
+        ServiceClient<RundeckApi> serviceClient = getClient();
         apiCall(api -> api.deleteSystemAclPolicy(options.getName()));
         output.output(String.format("Deleted System ACL Policy: %s", options.getName()));
     }

--- a/src/main/java/org/rundeck/client/tool/commands/system/Mode.java
+++ b/src/main/java/org/rundeck/client/tool/commands/system/Mode.java
@@ -12,7 +12,6 @@ import org.rundeck.client.api.model.SystemMode;
 import org.rundeck.client.tool.RdApp;
 import org.rundeck.client.tool.commands.AppCommand;
 import org.rundeck.client.tool.options.QuietOption;
-import org.rundeck.client.util.Client;
 import org.rundeck.client.util.ServiceClient;
 import retrofit2.Call;
 
@@ -72,7 +71,7 @@ public class Mode extends AppCommand {
 
     @Command(description = "Set execution mode Active")
     public boolean active(ModeActive opts, CommandOutput output) throws IOException, InputError {
-        return changeMode(opts, output, ExecutionMode.active, RundeckApi::executionModeEnable, getClient());
+        return changeMode(opts, output, ExecutionMode.active, RundeckApi::executionModeEnable);
     }
 
     @CommandLineInterface(application = "passive") interface ModePassive extends QuietOption {
@@ -81,22 +80,21 @@ public class Mode extends AppCommand {
 
     @Command(description = "Set execution mode Passive")
     public boolean passive(ModePassive opts, CommandOutput output) throws IOException, InputError {
-        return changeMode(opts, output, ExecutionMode.passive, RundeckApi::executionModeDisable, getClient());
+        return changeMode(opts, output, ExecutionMode.passive, RundeckApi::executionModeDisable);
     }
 
-    static boolean changeMode(
+    boolean changeMode(
             final QuietOption opts,
             final CommandOutput output,
             final ExecutionMode expected,
-            final Function<RundeckApi, Call<SystemMode>> operation,
-            final ServiceClient<RundeckApi> client
+            final Function<RundeckApi, Call<SystemMode>> operation
     )
             throws InputError, IOException
     {
         if (!opts.isQuiet()) {
             output.info(String.format("Setting execution mode to %s...", expected));
         }
-        SystemMode mode = apiCall(client, operation);
+        SystemMode mode = apiCall(operation);
         if (!opts.isQuiet()) {
             output.info("Execution Mode is now:");
             output.output(mode.getExecutionMode());

--- a/src/main/java/org/rundeck/client/tool/commands/system/Mode.java
+++ b/src/main/java/org/rundeck/client/tool/commands/system/Mode.java
@@ -13,6 +13,7 @@ import org.rundeck.client.tool.RdApp;
 import org.rundeck.client.tool.commands.AppCommand;
 import org.rundeck.client.tool.options.QuietOption;
 import org.rundeck.client.util.Client;
+import org.rundeck.client.util.ServiceClient;
 import retrofit2.Call;
 
 import java.io.IOException;
@@ -88,7 +89,7 @@ public class Mode extends AppCommand {
             final CommandOutput output,
             final ExecutionMode expected,
             final Function<RundeckApi, Call<SystemMode>> operation,
-            final Client<RundeckApi> client
+            final ServiceClient<RundeckApi> client
     )
             throws InputError, IOException
     {

--- a/src/main/java/org/rundeck/client/util/Client.java
+++ b/src/main/java/org/rundeck/client/util/Client.java
@@ -203,7 +203,6 @@ public class Client<T> implements ServiceClient<T> {
     public <R> R checkErrorDowngradable(final Response<R> response) throws IOException, UnsupportedVersion {
         if (!response.isSuccessful()) {
             ErrorDetail error = readError(response);
-            System.err.println("error: " + error);
             checkUnsupportedVersion(response, error);
             return handleError(response, error);
         }
@@ -213,7 +212,6 @@ public class Client<T> implements ServiceClient<T> {
     private <R> R handleError(final Response<R> response, final ErrorDetail error) {
         reportApiError(error);
         throw makeErrorThrowable(response, error);
-
     }
 
     private <R> RequestFailed makeErrorThrowable(final Response<R> response, final ErrorDetail error) {

--- a/src/main/java/org/rundeck/client/util/FormAuthInterceptor.java
+++ b/src/main/java/org/rundeck/client/util/FormAuthInterceptor.java
@@ -86,7 +86,7 @@ public class FormAuthInterceptor implements Interceptor {
                 //jetty behavior: redirect to login error page
                 throw new LoginFailed(String.format("Password Authentication failed for: %s", username));
             }
-            if (null == authResponse.priorResponse() && Client.hasAnyMediaType(
+            if (null == authResponse.priorResponse() && ServiceClient.hasAnyMediaType(
                     authResponse.body(),
                     MediaType.parse("text/html")
             )) {

--- a/src/main/java/org/rundeck/client/util/ServiceClient.java
+++ b/src/main/java/org/rundeck/client/util/ServiceClient.java
@@ -1,0 +1,142 @@
+package org.rundeck.client.util;
+
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import org.rundeck.client.api.model.ErrorDetail;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+/**
+ * @author greg
+ * @since 10/19/17
+ */
+public interface ServiceClient<T> {
+    /**
+     * @param body  body
+     * @param types list of media types
+     *
+     * @return true if body has one of the media types
+     */
+    static boolean hasAnyMediaType(ResponseBody body, MediaType... types) {
+        MediaType mediaType1 = body.contentType();
+        for (MediaType mediaType : types) {
+            if (mediaType1.type().equals(mediaType.type()) && mediaType1.subtype().equals(mediaType.subtype())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Execute the remote call, and return the expected type if successful. if unsuccessful
+     * throw an exception with relevant error detail
+     *
+     * @param execute call
+     * @param <R>     expected result type
+     *
+     * @return result
+     *
+     * @throws IOException if remote call is unsuccessful or parsing error occurs
+     */
+    <R> R checkError(Call<R> execute) throws IOException;
+
+    /**
+     * Execute the remote call, and return the expected type if successful. if unsuccessful
+     * throw an exception with relevant error detail
+     *
+     * @param execute call
+     * @param <R>     expected result type
+     *
+     * @return result
+     *
+     * @throws IOException if remote call is unsuccessful or parsing error occurs
+     */
+    <R> R checkErrorDowngradable(Call<R> execute) throws IOException, Client.UnsupportedVersion;
+
+    /**
+     * @return the base URL used without API path
+     */
+    String getAppBaseUrl();
+
+    /**
+     * @return the API URL used
+     */
+    String getApiBaseUrl();
+
+    /**
+     * return the expected type if successful. if response is unsuccessful
+     * throw an exception with relevant error detail
+     *
+     * @param response call response
+     * @param <R>      expected type
+     *
+     * @return result
+     *
+     * @throws IOException if remote call is unsuccessful or parsing error occurs
+     */
+    <R> R checkError(Response<R> response) throws IOException;
+
+    /**
+     * return the expected type if successful. if response is unsuccessful
+     * throw an exception with relevant error detail
+     *
+     * @param response call response
+     * @param <R>      expected type
+     *
+     * @return result
+     *
+     * @throws IOException if remote call is unsuccessful or parsing error occurs
+     */
+    <R> R checkErrorDowngradable(Response<R> response) throws IOException, Client.UnsupportedVersion;
+
+    void reportApiError(ErrorDetail error);
+
+    /**
+     * If the response has one of the expected media types, parse into the error type
+     *
+     * @param execute    response
+     * @param errorType  class of response
+     * @param mediaTypes expected media types
+     * @param <X>        error type
+     *
+     * @return error type instance, or null if mediate type does not match
+     *
+     * @throws IOException if media type matched, but parsing was unsuccessful
+     */
+    @SuppressWarnings("SameParameterValue")
+    <X> X readError(Response<?> execute, Class<X> errorType, MediaType... mediaTypes) throws IOException;
+
+    /**
+     * call a function using the service
+     *
+     * @param func function using the service
+     * @param <U>  result type
+     *
+     * @return result
+     *
+     * @throws IOException if an error occurs
+     */
+    <U> U apiCall(Function<T, Call<U>> func) throws IOException;
+
+    /**
+     * call a function using the service
+     *
+     * @param func function using the service
+     * @param <U>  result type
+     *
+     * @return result
+     *
+     * @throws IOException if an error occurs
+     */
+    <U> U apiCallDowngradable(Function<T, Call<U>> func) throws IOException, Client.UnsupportedVersion;
+
+    T getService();
+
+    Retrofit getRetrofit();
+
+    int getApiVersion();
+}

--- a/src/main/java/org/rundeck/client/util/ServiceClient.java
+++ b/src/main/java/org/rundeck/client/util/ServiceClient.java
@@ -55,7 +55,7 @@ public interface ServiceClient<T> {
      *
      * @throws IOException if remote call is unsuccessful or parsing error occurs
      */
-    <R> R checkErrorDowngradable(Call<R> execute) throws IOException, Client.UnsupportedVersion;
+    <R> R checkErrorDowngradable(Call<R> execute) throws IOException, Client.UnsupportedVersionDowngrade;
 
     /**
      * @return the base URL used without API path
@@ -91,7 +91,7 @@ public interface ServiceClient<T> {
      *
      * @throws IOException if remote call is unsuccessful or parsing error occurs
      */
-    <R> R checkErrorDowngradable(Response<R> response) throws IOException, Client.UnsupportedVersion;
+    <R> R checkErrorDowngradable(Response<R> response) throws IOException, Client.UnsupportedVersionDowngrade;
 
     void reportApiError(ErrorDetail error);
 
@@ -132,7 +132,7 @@ public interface ServiceClient<T> {
      *
      * @throws IOException if an error occurs
      */
-    <U> U apiCallDowngradable(Function<T, Call<U>> func) throws IOException, Client.UnsupportedVersion;
+    <U> U apiCallDowngradable(Function<T, Call<U>> func) throws IOException, Client.UnsupportedVersionDowngrade;
 
     T getService();
 

--- a/src/test/groovy/org/rundeck/client/tool/commands/AppCommandSpec.groovy
+++ b/src/test/groovy/org/rundeck/client/tool/commands/AppCommandSpec.groovy
@@ -1,0 +1,113 @@
+package org.rundeck.client.tool.commands
+
+import okhttp3.MediaType
+import okhttp3.ResponseBody
+import org.rundeck.client.api.RequestFailed
+import org.rundeck.client.api.RundeckApi
+import org.rundeck.client.tool.RdApp
+import org.rundeck.client.util.Client
+import org.rundeck.client.util.ServiceClient
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.jackson.JacksonConverterFactory
+import retrofit2.mock.Calls
+import spock.lang.Specification
+
+/**
+ * @author greg
+ * @since 10/19/17
+ */
+class AppCommandSpec extends Specification {
+    def "check error with api version downgrade"() {
+        given:
+
+        def retrofit = new Retrofit.Builder().baseUrl('http://test').
+                addConverterFactory(JacksonConverterFactory.create()).
+                build()
+        ServiceClient<RundeckApi> client = new Client(
+                Mock(RundeckApi),
+                retrofit,
+                "appBaseUrl",
+                "apiBaseUrl",
+                21,
+                true,
+                null
+        )
+        ServiceClient<RundeckApi> client2 = Mock(ServiceClient)
+
+        def app = Mock(RdApp) {
+            getClient() >> client
+        }
+
+        def cmd = new AppCommand(app) {
+
+        }
+
+
+        when:
+        def result = cmd.apiCall {
+            Calls.response(
+                    Response.error(
+                            400,
+                            ResponseBody.create(
+                                    MediaType.parse('application/json'),
+                                    '{"error":true,"apiversion":20,"errorCode":"api.error.api-version.unsupported",' +
+                                            '"message":"Unsupported API Version \\"21\\". API Request: ' +
+                                            '/api/21/projects. Reason: Current version: 20"}'
+                            )
+                    )
+            )
+        }
+
+        then:
+        1 * app.getClient(20) >> client2
+        1 * client2.apiCall(_) >> 'test result'
+        result == 'test result'
+    }
+
+    def "check error without api version downgrade"() {
+        given:
+
+        def retrofit = new Retrofit.Builder().baseUrl('http://test').
+                addConverterFactory(JacksonConverterFactory.create()).
+                build()
+        ServiceClient<RundeckApi> client = new Client(
+                Mock(RundeckApi),
+                retrofit,
+                "appBaseUrl",
+                "apiBaseUrl",
+                21,
+                false,
+                Mock(Client.Logger)
+        )
+        ServiceClient<RundeckApi> client2 = Mock(ServiceClient)
+
+        def app = Mock(RdApp) {
+            getClient() >> client
+        }
+
+        def cmd = new AppCommand(app) {
+
+        }
+
+
+        when:
+        def result = cmd.apiCall {
+            Calls.response(
+                    Response.error(
+                            400,
+                            ResponseBody.create(
+                                    MediaType.parse('application/json'),
+                                    '{"error":true,"apiversion":20,"errorCode":"api.error.api-version.unsupported",' +
+                                            '"message":"Unsupported API Version \\"21\\". API Request: ' +
+                                            '/api/21/projects. Reason: Current version: 20"}'
+                            )
+                    )
+            )
+        }
+
+        then:
+        RequestFailed e = thrown()
+        e.message=='Request failed: 400 null'
+    }
+}

--- a/src/test/groovy/org/rundeck/client/tool/commands/ExecutionsSpec.groovy
+++ b/src/test/groovy/org/rundeck/client/tool/commands/ExecutionsSpec.groovy
@@ -49,7 +49,7 @@ class ExecutionsSpec extends Specification {
         def api = Mock(RundeckApi)
 
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 18)
+        def client = new Client(api, retrofit, null, null, 18, true, null)
 
         ExecOutput execOutput = new ExecOutput()
         execOutput.execState = initState

--- a/src/test/groovy/org/rundeck/client/tool/commands/JobsSpec.groovy
+++ b/src/test/groovy/org/rundeck/client/tool/commands/JobsSpec.groovy
@@ -60,7 +60,7 @@ class JobsSpec extends Specification {
             getGroup() >> group
         }
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 17)
+        def client = new Client(api, retrofit, null, null, 17, true, null)
         def hasclient = Mock(RdApp) {
             getClient() >> client
         }
@@ -96,7 +96,7 @@ class JobsSpec extends Specification {
             getFile() >> tempFile
         }
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 17)
+        def client = new Client(api, retrofit, null, null, 17, true, null)
         def hasclient = Mock(RdApp) {
             getClient() >> client
         }
@@ -138,7 +138,7 @@ class JobsSpec extends Specification {
             isConfirm() >> true
         }
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 17)
+        def client = new Client(api, retrofit, null, null, 17, true, null)
         def hasclient = Mock(RdApp) {
             getClient() >> client
         }
@@ -178,7 +178,7 @@ class JobsSpec extends Specification {
             isConfirm() >> true
         }
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 17)
+        def client = new Client(api, retrofit, null, null, 17, true, null)
         def hasclient = Mock(RdApp) {
             getClient() >> client
         }
@@ -204,7 +204,7 @@ class JobsSpec extends Specification {
         }
 
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 18)
+        def client = new Client(api, retrofit, null, null, 18, true, null)
         def hasclient = Mock(RdApp) {
             getClient() >> client
         }
@@ -235,7 +235,7 @@ class JobsSpec extends Specification {
             getFile() >> tempFile
         }
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 17)
+        def client = new Client(api, retrofit, null, null, 17, true, null)
         def hasclient = Mock(RdApp) {
             getClient() >> client
         }

--- a/src/test/groovy/org/rundeck/client/tool/commands/KeysSpec.groovy
+++ b/src/test/groovy/org/rundeck/client/tool/commands/KeysSpec.groovy
@@ -168,7 +168,7 @@ class KeysSpec extends Specification {
         }
 
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 18)
+        def client = new Client(api, retrofit, null, null, 18, true, null)
         def hasclient = Mock(RdApp) {
             getClient() >> client
         }
@@ -230,7 +230,7 @@ class KeysSpec extends Specification {
                 build()
         def api = retrofit.create(RundeckApi)
         def out = Mock(CommandOutput)
-        def client = new Client(api, retrofit, 18)
+        def client = new Client(api, retrofit, null, null, 18, true, null)
         def hasclient = Mock(RdApp) {
             getClient() >> client
         }

--- a/src/test/groovy/org/rundeck/client/tool/commands/ProjectsSpec.groovy
+++ b/src/test/groovy/org/rundeck/client/tool/commands/ProjectsSpec.groovy
@@ -19,7 +19,6 @@ package org.rundeck.client.tool.commands
 import com.simplifyops.toolbelt.CommandOutput
 import org.rundeck.client.api.RundeckApi
 import org.rundeck.client.api.model.ProjectItem
-import org.rundeck.client.api.model.ScheduledJobItem
 import org.rundeck.client.tool.RdApp
 import org.rundeck.client.util.Client
 import retrofit2.Retrofit
@@ -42,7 +41,7 @@ class ProjectsSpec extends Specification {
         }
 
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 18)
+        def client = new Client(api, retrofit, null, null, 18, true, null)
         def hasclient = Mock(RdApp) {
             getClient() >> client
         }

--- a/src/test/groovy/org/rundeck/client/tool/commands/RunSpec.groovy
+++ b/src/test/groovy/org/rundeck/client/tool/commands/RunSpec.groovy
@@ -48,7 +48,7 @@ class RunSpec extends Specification {
             getJob() >> 'a group/path/a job'
         }
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 17)
+        def client = new Client(api, retrofit, null, null, 17, true, null)
         def hasclient = Mock(RdApp) {
             getClient() >> client
         }
@@ -79,7 +79,7 @@ class RunSpec extends Specification {
             getJob() >> 'a group/path/a job'
         }
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 17)
+        def client = new Client(api, retrofit, null, null, 17, true, null)
         def appConfig = Mock(AppConfig)
         def hasclient = Mock(RdApp) {
             getClient() >> client
@@ -126,7 +126,7 @@ class RunSpec extends Specification {
             ].collect { it.toString() }
         }
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 19)
+        def client = new Client(api, retrofit, null, null, 19, true, null)
         def appConfig = Mock(AppConfig)
         def hasclient = Mock(RdApp) {
             getClient() >> client

--- a/src/test/groovy/org/rundeck/client/tool/commands/TokensSpec.groovy
+++ b/src/test/groovy/org/rundeck/client/tool/commands/TokensSpec.groovy
@@ -126,7 +126,7 @@ class TokensSpec extends Specification {
             isUser() >> true
         }
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 18)
+        def client = new Client(api, retrofit, null, null, 18, true, null)
         def hasclient = Mock(RdApp) {
             getClient() >> client
         }
@@ -162,7 +162,7 @@ class TokensSpec extends Specification {
             isRoles() >> true
         }
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 19)
+        def client = new Client(api, retrofit, null, null, 19, true, null)
         def hasclient = Mock(RdApp) {
             getClient() >> client
         }

--- a/src/test/groovy/org/rundeck/client/tool/commands/projects/SCMSpec.groovy
+++ b/src/test/groovy/org/rundeck/client/tool/commands/projects/SCMSpec.groovy
@@ -17,9 +17,6 @@
 package org.rundeck.client.tool.commands.projects
 
 import com.simplifyops.toolbelt.CommandOutput
-import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
-import okhttp3.mockwebserver.RecordedRequest
 import org.rundeck.client.api.RundeckApi
 import org.rundeck.client.api.model.ScmActionInputsResult
 import org.rundeck.client.api.model.ScmImportItem
@@ -31,7 +28,6 @@ import org.rundeck.client.tool.AppConfig
 import org.rundeck.client.tool.RdApp
 import org.rundeck.client.util.Client
 import retrofit2.Retrofit
-import retrofit2.converter.jackson.JacksonConverterFactory
 import retrofit2.mock.Calls
 import spock.lang.Specification
 
@@ -45,7 +41,7 @@ class SCMSpec extends Specification {
         def api = Mock(RundeckApi)
 
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 18)
+        def client = new Client(api, retrofit, null, null, 18, true, null)
 
         def appConfig = Mock(AppConfig)
 
@@ -130,7 +126,7 @@ class SCMSpec extends Specification {
         def api = Mock(RundeckApi)
 
         def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
-        def client = new Client(api, retrofit, 18)
+        def client = new Client(api, retrofit, null, null, 18, true, null)
 
         def appConfig = Mock(AppConfig)
 


### PR DESCRIPTION
* `RD_API_DOWNGRADE=true` will enable automatic downgrading. If unsupported version is reported by the server, and a lower supported version is reported, `rd` will automatically use the supplied version.  A warning will be printed.
* `RD_API_VERSION=X` will force an api version independent of URL
* Errors no longer show stacktraces by default, but are enabled if `RD_DEBUG` is set.

