### PR TITLE
Fix #62 add flags to scm perform to include items automatically

### DIFF
--- a/src/main/java/org/rundeck/client/api/model/ScmActionInputsResult.java
+++ b/src/main/java/org/rundeck/client/api/model/ScmActionInputsResult.java
@@ -17,15 +17,18 @@
 package org.rundeck.client.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.simplifyops.toolbelt.Formatable;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author greg
  * @since 12/13/16
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ScmActionInputsResult {
+public class ScmActionInputsResult implements Formatable {
     public String title;
     public String description;
     public String integration;
@@ -33,4 +36,29 @@ public class ScmActionInputsResult {
     public List<ScmInputField> fields;
     public List<ScmImportItem> importItems;
     public List<ScmExportItem> exportItems;
+
+    @Override
+    public List<?> asList() {
+        return null;
+    }
+
+    @Override
+    public Map<?, ?> asMap() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("title", title);
+        map.put("description", description);
+        map.put("integration", integration);
+        map.put("actionId", actionId);
+        if (null != fields) {
+            map.put("fields", fields);
+        }
+        if (null != importItems) {
+            map.put("items", importItems);
+        }
+        if (null != exportItems) {
+            map.put("items", exportItems);
+        }
+
+        return map;
+    }
 }

--- a/src/main/java/org/rundeck/client/api/model/ScmExportItem.java
+++ b/src/main/java/org/rundeck/client/api/model/ScmExportItem.java
@@ -17,8 +17,10 @@
 package org.rundeck.client.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.simplifyops.toolbelt.Formatable;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -26,14 +28,19 @@ import java.util.Map;
  * @since 12/13/16
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ScmExportItem {
+public class ScmExportItem implements Formatable{
     public String itemId;
     public String originalId;
     public ScmJobItem job;
     public Boolean renamed;
     public Boolean deleted;
 
-    public Map toMap() {
+    @Override
+    public List<?> asList() {
+        return null;
+    }
+
+    public Map asMap() {
         HashMap<String, Object> map = new HashMap<>();
         map.put("itemId", itemId);
         if (null != originalId) {

--- a/src/main/java/org/rundeck/client/api/model/ScmExportItem.java
+++ b/src/main/java/org/rundeck/client/api/model/ScmExportItem.java
@@ -33,7 +33,7 @@ public class ScmExportItem implements Formatable{
     public String originalId;
     public ScmJobItem job;
     public Boolean renamed;
-    public Boolean deleted;
+    private Boolean deleted;
 
     @Override
     public List<?> asList() {
@@ -52,5 +52,13 @@ public class ScmExportItem implements Formatable{
         map.put("renamed", renamed);
         map.put("deleted", deleted);
         return map;
+    }
+
+    public boolean getDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
     }
 }

--- a/src/main/java/org/rundeck/client/api/model/ScmImportItem.java
+++ b/src/main/java/org/rundeck/client/api/model/ScmImportItem.java
@@ -17,8 +17,10 @@
 package org.rundeck.client.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.simplifyops.toolbelt.Formatable;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -26,12 +28,17 @@ import java.util.Map;
  * @since 12/13/16
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ScmImportItem {
+public class ScmImportItem implements Formatable {
     public String itemId;
     public Boolean tracked;
     public ScmJobItem job;
 
-    public Map toMap() {
+    @Override
+    public List<?> asList() {
+        return null;
+    }
+
+    public Map asMap() {
         HashMap<String, Object> map = new HashMap<>();
         map.put("itemId", itemId);
         map.put("tracked", tracked);

--- a/src/main/java/org/rundeck/client/api/model/ScmInputField.java
+++ b/src/main/java/org/rundeck/client/api/model/ScmInputField.java
@@ -16,6 +16,8 @@
 
 package org.rundeck.client.api.model;
 
+import com.simplifyops.toolbelt.Formatable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +26,7 @@ import java.util.Map;
  * @author greg
  * @since 12/13/16
  */
-public class ScmInputField {
+public class ScmInputField implements Formatable{
     public String defaultValue;
     public String description;
     public String name;
@@ -35,7 +37,7 @@ public class ScmInputField {
     public String type;
     public List<String> values;
 
-    public Map toMap() {
+    public Map<?, ?> asMap() {
         HashMap<String, Object> map = new HashMap<>();
         map.put("name", name);
         map.put("title", title);
@@ -47,4 +49,10 @@ public class ScmInputField {
         map.put("values", values);
         return map;
     }
+
+    @Override
+    public List<?> asList() {
+        return null;
+    }
+
 }

--- a/src/main/java/org/rundeck/client/api/model/ScmSetupInputsResult.java
+++ b/src/main/java/org/rundeck/client/api/model/ScmSetupInputsResult.java
@@ -16,14 +16,32 @@
 
 package org.rundeck.client.api.model;
 
+import com.simplifyops.toolbelt.Formatable;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author greg
  * @since 12/13/16
  */
-public class ScmSetupInputsResult {
+public class ScmSetupInputsResult implements Formatable {
     public String integration;
     public String type;
     public List<ScmInputField> fields;
+
+    @Override
+    public List<?> asList() {
+        return null;
+    }
+
+    @Override
+    public Map<?, ?> asMap() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("integration", integration);
+        map.put("type", type);
+        map.put("fields", fields);
+        return map;
+    }
 }

--- a/src/main/java/org/rundeck/client/tool/commands/projects/SCM.java
+++ b/src/main/java/org/rundeck/client/tool/commands/projects/SCM.java
@@ -298,7 +298,7 @@ public class SCM extends AppCommand {
 
         @Option(shortName = "D",
                 longName = "alldeleted",
-                description = "Include all modified (not deleted) items from the result of calling Inputs in Export " +
+                description = "Include all deleted items from the result of calling Inputs in Export " +
                               "action (export only)")
         boolean isAllDeletedItems();
 

--- a/src/main/java/org/rundeck/client/tool/commands/projects/SCM.java
+++ b/src/main/java/org/rundeck/client/tool/commands/projects/SCM.java
@@ -31,6 +31,7 @@ import org.rundeck.client.tool.commands.AppCommand;
 import org.rundeck.client.tool.RdApp;
 import org.rundeck.client.tool.options.OptionUtil;
 import org.rundeck.client.tool.options.ProjectNameOptions;
+import org.rundeck.client.tool.options.VerboseOption;
 import org.rundeck.client.util.Client;
 import org.rundeck.client.util.Colorz;
 import org.rundeck.client.util.ServiceClient;
@@ -213,7 +214,7 @@ public class SCM extends AppCommand {
     }
 
     @CommandLineInterface(application = "setupinputs")
-    public interface InputsOptions extends BaseScmOptions {
+    public interface InputsOptions extends BaseScmOptions, VerboseOption {
         @Option(longName = "type", shortName = "t", description = "Plugin type")
         String getType();
     }
@@ -229,11 +230,16 @@ public class SCM extends AppCommand {
                 options.getType()
         ));
 
-        output.output(result.fields.stream().map(ScmInputField::toMap).collect(Collectors.toList()));
+        if (options.isVerbose()) {
+            output.output(result);
+            return;
+        }
+
+        output.output(result.fields.stream().map(ScmInputField::asMap).collect(Collectors.toList()));
     }
 
-    @CommandLineInterface(application = "setupinputs")
-    public interface ActionInputsOptions extends BaseScmOptions {
+    @CommandLineInterface(application = "inputs")
+    public interface ActionInputsOptions extends BaseScmOptions, VerboseOption {
         @Option(longName = "action", shortName = "a", description = "Action ID")
         String getAction();
 
@@ -249,14 +255,18 @@ public class SCM extends AppCommand {
                 options.getAction()
         ));
 
+        if (options.isVerbose()) {
+            output.output(result);
+            return;
+        }
         output.output(result.title + ": " + result.description);
         output.output("Fields:");
-        output.output(result.fields.stream().map(ScmInputField::toMap).collect(Collectors.toList()));
+        output.output(result.fields.stream().map(ScmInputField::asMap).collect(Collectors.toList()));
         output.output("Items:");
         if ("export".equals(options.getIntegration())) {
-            output.output(result.exportItems.stream().map(ScmExportItem::toMap).collect(Collectors.toList()));
+            output.output(result.exportItems.stream().map(ScmExportItem::asMap).collect(Collectors.toList()));
         } else {
-            output.output(result.importItems.stream().map(ScmImportItem::toMap).collect(Collectors.toList()));
+            output.output(result.importItems.stream().map(ScmImportItem::asMap).collect(Collectors.toList()));
         }
     }
 


### PR DESCRIPTION
Updates `projects scm perform` to allow including items automatically, instead of requiring them to be specified manually.

flags for export: 
* `-A/--allitems` includes all changes (modified or deleted jobs)
* `-M/--allmodified` includes all modified jobs
* `-D/--alldeleted` includes deleted jobs

flags for import: 
* `-A/--allitems` includes all files (tracked and untracked)
* `-T/--alltracked` includes all "tracked" files (matching already imported jobs)
* `-U/--alluntracked` includes all "untracked" files (not matching existing jobs)

Using these flags will query for items from the `inputs` response, and adds all items to the action automatically that match the criteria.

Examples

Commit all modified jobs: `rd projects scm perform -a project-commit -i export -p MyProject -f 'message=My commit' -M`

Commit all changes: `rd projects scm perform -a project-commit -i export -p MyProject -f 'message=My commit' -A`

Import all changes: `rd projects scm perform -i import -p MyProject -a import-all -A`

---

Also updates `rd projects scm inputs/setupinputs` to add `-v` making the output more useful in scripting scenarios when RD_FORMAT is used:

~~~
RD_FORMAT=json rd projects scm inputs -i import -p MyProject -a import-all -v | jq .
{
  "integration": "import",
  "description": "Import the modifications to Rundeck",
  "actionId": "import-all",
  "title": "Import remote Changes",
  "fields": [],
  "items": [
    {
      "itemId": "bilk-a67a5f69-d467-4c15-bba5-e080dcd6a976.xml",
      "tracked": true,
      "job": {
        "jobId": "b0e5aa0d-aa41-4ba4-9257-3d60ea1184a7",
        "jobName": "bilk",
        "groupPath": null
      }
    },
    {
      "itemId": "flimble-865756f7-892c-4caa-bb15-5083afa689b9.xml",
      "tracked": true,
      "job": {
        "jobId": "9cf4a549-08e8-4ed3-8636-ba28293a036f",
        "jobName": "flimble",
        "groupPath": null
      }
    },
    {
      "itemId": "simbal-14ee330f-565c-476c-8c3b-90465c40d7de.xml",
      "tracked": true,
      "job": {
        "jobId": "c535c1b1-7499-49ea-8800-fde070179821",
        "jobName": "simbal",
        "groupPath": null
      }
    }
  ]
}
~~~