### PR TITLE
Keep environment variables consistent across documentation

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -19,7 +19,7 @@ Specifying formatted output for Job and Execution lists:
 
 For `rd executions` you can customize the default date format of `yyyy-MM-ddHH:mm:ssZ`:
 
-    DATE_FORMAT="yyyy-MM-dd HH:mm z"
+    RD_DATE_FORMAT="yyyy-MM-dd HH:mm z"
 
 See [Java SimpleDateFormat][1]
 

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -61,6 +61,6 @@ If you used a different trust store "type" you can also set that with this opt:
 
 Then, [Setup your Rundeck connection info]({{site.url}}{{site.baseurl}}/configuration/), and you can use `rd`.
 
-	export RUNDECK_URL="https://$HOST:$PORT/api/18"
-	export RUNDECK_TOKEN="..."
+	export RD_URL="https://$HOST:$PORT/api/18"
+	export RD_TOKEN="..."
 	rd system


### PR DESCRIPTION
Replaced RUNDECK_URL, RUNDECK_TOKEN, and DATE_FORMAT with RD_* equivalents across documentation files.