### PR TITLE
Add install docs for Arch Linux

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -10,8 +10,9 @@ Download all artifacts from: [github releases](https://github.com/rundeck/rundec
 
 * [zip install](#zip-install) `rd-x.y.zip`/`rd-x.y.tar`
 * [standalone executable jar](#jar-install) `rundeck-cli-x.y-all.jar`
-* [rpm install](#yum-install) `rundeck-cli-x.y.noarch.rpm`
-* [debian install](#debian-install) `rundeck-cli-x.y_all.deb`
+* [rpm install](#yum-usage) `rundeck-cli-x.y.noarch.rpm`
+* [debian install](#debian-usage) `rundeck-cli-x.y_all.deb`
+* [arch install](#arch-install)
 
 Additional Yum/Debian repos hosted by:
 
@@ -74,3 +75,14 @@ apt-get -y install apt-transport-https
 apt-get -y update
 apt-get -y install rundeck-cli
 ~~~
+
+### Arch Linux install
+
+Make sure you're familiarized with [the AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository)
+
+~~~{.sh}
+git clone https://aur.archlinux.org/rundeck-cli.git
+cd rundeck-cli
+makepkg -i
+~~~
+

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,7 +12,7 @@ Download all artifacts from: [github releases](https://github.com/rundeck/rundec
 * [standalone executable jar](#jar-install) `rundeck-cli-x.y-all.jar`
 * [rpm install](#yum-usage) `rundeck-cli-x.y.noarch.rpm`
 * [debian install](#debian-usage) `rundeck-cli-x.y_all.deb`
-* [arch install](#arch-install)
+* [arch install](#arch-linux-install)
 
 Additional Yum/Debian repos hosted by:
 


### PR DESCRIPTION
I made and have been maintaining a [simple Arch package in the Arch User Repositories (AUR)](https://aur.archlinux.org/packages/rundeck-cli). Might be nice to get it in the install docs :)

Also fixed the anchors for rpm/debian sections, as they weren't working before.