### PR TITLE
added env var RD_INSECURE_SSL_NO_WARN handling

### DIFF
--- a/rd-api-client/src/main/java/org/rundeck/client/RundeckClient.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/RundeckClient.java
@@ -47,6 +47,7 @@ public class RundeckClient {
     public static final Pattern API_VERS_PATTERN = Pattern.compile("^(.*)(/api/(\\d+)/?)$");
     public static final String ENV_BYPASS_URL = "RD_BYPASS_URL";
     public static final String ENV_INSECURE_SSL = "RD_INSECURE_SSL";
+    public static final String ENV_INSECURE_SSL_NO_WARN = "RD_INSECURE_SSL_NO_WARN";
     public static final String ENV_INSECURE_SSL_HOSTNAME = "RD_INSECURE_SSL_HOSTNAME";
     public static final String ENV_ALT_SSL_HOSTNAME = "RD_ALT_SSL_HOSTNAME";
     public static final String ENV_HTTP_TIMEOUT = "RD_HTTP_TIMEOUT";

--- a/src/main/java/org/rundeck/client/tool/Main.java
+++ b/src/main/java/org/rundeck/client/tool/Main.java
@@ -41,6 +41,7 @@ import java.util.*;
 import java.util.function.Function;
 
 import static org.rundeck.client.RundeckClient.ENV_INSECURE_SSL;
+import static org.rundeck.client.RundeckClient.ENV_INSECURE_SSL_NO_WARN;
 
 
 /**
@@ -194,7 +195,8 @@ public class Main {
                 "rundeck.client.insecure.ssl",
                 System.getenv(ENV_INSECURE_SSL)
         ));
-        if (insecureSsl) {
+        boolean insecureSslNoWarn = Boolean.parseBoolean(System.getenv(ENV_INSECURE_SSL_NO_WARN));
+        if (insecureSsl && !insecureSslNoWarn ) {
             belt.finalOutput().warning(
                     "# WARNING: RD_INSECURE_SSL=true, no hostname or certificate trust verification will be performed");
         }


### PR DESCRIPTION
to suppress warnings about insecure ssl

Before this patch, when you use a self-signed ssl cert in a rundeck setup, rd tools will always present the line:

# WARNING: RD_INSECURE_SSL=true, no hostname or certificate trust verification will be performed

This change will suppress such warnings if you add the line

export RD_INSECURE_SSL_NO_WARN=true

in ~/.rd/rd.conf file.