### PR TITLE
Upgrade OKHTTP to a version that includes sha384

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,7 +192,7 @@ dependencies {
     testCompile project(":rd-api-client")
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile 'com.squareup.retrofit2:retrofit-mock:2.1.0'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.4.1'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.5.0'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     testCompile "org.codehaus.groovy:groovy-all:2.3.7"
     testCompile "org.spockframework:spock-core:0.7-groovy-2.0"

--- a/rd-api-client/build.gradle
+++ b/rd-api-client/build.gradle
@@ -36,13 +36,13 @@ dependencies {
     compile 'com.squareup.retrofit2:retrofit:2.1.0'
     compile 'com.squareup.retrofit2:converter-jackson:2.1.0'
     compile 'com.squareup.retrofit2:converter-simplexml:2.1.0'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.4.1'
-    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.4.1'
+    compile 'com.squareup.okhttp3:logging-interceptor:3.5.0'
+    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.5.0'
 
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile 'com.squareup.retrofit2:retrofit-mock:2.1.0'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.4.1'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.5.0'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     testCompile "org.codehaus.groovy:groovy-all:2.3.7"
     testCompile "org.spockframework:spock-core:0.7-groovy-2.0"


### PR DESCRIPTION
fixes #217 

This may resolve the issue a user is facing with supported cipher suites. This version of OKHTTP appears to have the necessary cipher suite in the approved list: https://github.com/square/okhttp/blob/parent-3.5.0/okhttp/src/main/java/okhttp3/ConnectionSpec.java#L49 .