### PR TITLE
Fix #242 overwrite symlink if present, and remove on uninstall, add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ jobs:
       script: bash scripts/deb-install.sh
     - stage: rpm install test
       script: bash scripts/rpm-install.sh
+    - stage: rpm upgrade test
+      script: bash scripts/rpm-upgrade.sh
 after_success:
 - mkdir $HOME/.gnupg
 - openssl aes-256-cbc -K $encrypted_168997f84686_key -iv $encrypted_168997f84686_iv

--- a/dockers/install/upgrade-rpm/Dockerfile
+++ b/dockers/install/upgrade-rpm/Dockerfile
@@ -1,0 +1,15 @@
+FROM centos:6
+#ARG OLDVER
+RUN yum -y update
+RUN yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel
+RUN curl -sS -f -L -o /etc/yum.repos.d/bintray.repo https://bintray.com/rundeck/rundeck-rpm/rpm
+
+RUN yum -y install rundeck-cli
+
+RUN rd pond
+
+COPY rundeck-cli-noarch.rpm /root/rundeck-cli-noarch.rpm
+
+RUN rpm -U /root/rundeck-cli-noarch.rpm
+
+CMD rd pond

--- a/rd-cli-tool/build.gradle
+++ b/rd-cli-tool/build.gradle
@@ -168,7 +168,12 @@ ospackage {
     //symlink /usr/bin/rd to the rd script
     postInstall(
             """
-/bin/ln -s \${RPM_INSTALL_PREFIX:-${distInstallPath}}/${archivedir}/bin/${applicationName} /usr/bin/${applicationName} 
+/bin/ln -sf \${RPM_INSTALL_PREFIX:-${distInstallPath}}/${archivedir}/bin/${applicationName} /usr/bin/${applicationName} 
+"""
+    )
+    postUninstall(
+            """
+rm /usr/bin/${applicationName} 
 """
     )
 }

--- a/scripts/rpm-upgrade.sh
+++ b/scripts/rpm-upgrade.sh
@@ -6,4 +6,4 @@ rpmfile=$(ls rd-cli-tool/build/distributions/rundeck-cli-*.noarch.rpm)
 
 cp $rpmfile dockers/install/upgrade-rpm/rundeck-cli-noarch.rpm
 docker build dockers/install/upgrade-rpm -t rdcli-rpm-upgrade
-docker run -it rdcli-rpm-upgrade rd
+docker run -it rdcli-rpm-upgrade rd pond

--- a/scripts/rpm-upgrade.sh
+++ b/scripts/rpm-upgrade.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+rpmfile=$(ls rd-cli-tool/build/distributions/rundeck-cli-*.noarch.rpm)
+
+cp $rpmfile dockers/install/upgrade-rpm/rundeck-cli-noarch.rpm
+docker build dockers/install/upgrade-rpm -t rdcli-rpm-upgrade
+docker run -it rdcli-rpm-upgrade rd


### PR DESCRIPTION
fix #242 

the /usr/bin/rd symlink is not removed on uninstall, causing upgrade to fail.

- [x] remove symlink when uninstalling
- [x] overwrite existing symlink during install, to prevent upgrade failure from previous releases