### PR TITLE
Update help text of rd run --quiet for clarity

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -38,7 +38,7 @@ Dispatch adhoc COMMAND to matching nodes.
 		[--outformat -% value] : Output format specifier for execution logs. You can use "%key" where key is one of:time,level,log,user,command,node. E.g. "%user@%node/%level: %log"
 		[--progress -r] : Do not echo log text, just an indicator that output is being received.
 		[--project -p /^[-_a-zA-Z0-9+][-\._a-zA-Z0-9+]*$/] : Project name
-		[--quiet -q] : Echo no output, just wait until the execution completes.
+		[--quiet -q] : Echo no output. Combine with -f/--follow to wait silently until the execution completes. Useful for non-interactive scripts.
 		[--restart -t] : Restart from the beginning
 		[--script -s value] : Dispatch specified script file
 		[--interpreter -i value] : Script interpreter string
@@ -209,7 +209,7 @@ Run a Job.
          [--loglevel -l /(verbose|info|warning|error)/] : Run the command using the specified LEVEL. LEVEL can be verbose, info, warning, error.
          [--progress -r] : Do not echo log text, just an indicator that output is being received.
          [--project -p value] : Project name
-         [--quiet -q] : Echo no output, just wait until the execution completes.
+         [--quiet -q] : Echo no output. Combine with -f/--follow to wait silently until the execution completes. Useful for non-interactive scripts.
          [--restart -t] : Restart from the beginning
          [--at -@ value] : Run the job at the specified date/time. ISO8601 format (yyyy-MM-dd'T'HH:mm:ss'Z')
          [--delay -d /(\d+[smhdwMY]\s*)+/] : Run the job at a certain time from now. Format: ##[smhdwMY] where ## is an integer and the units are seconds, minutes, hours, days, weeks, Months, Years. Can combine units, e.g. "2h30m", "20m30s"

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/options/FollowOptions.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/options/FollowOptions.java
@@ -20,7 +20,7 @@ import com.lexicalscope.jewel.cli.Option;
 
 public interface FollowOptions extends RunOptions{
 
-    @Option(shortName = "q", longName = "quiet", description = "Echo no output, just wait until the execution completes.")
+    @Option(shortName = "q", longName = "quiet", description = "Echo no output. Combine with -f/--follow to wait silently until the execution completes. Useful for non-interactive scripts.")
     boolean isQuiet();
 
     @Option(shortName = "r",


### PR DESCRIPTION
The previous help text for `rd run --quiet` implied that using -q option alone would make the command wait until completion, which is incorrect.

(merge of https://github.com/rundeck/rundeck-cli/pull/259)

---

The previous help text for rd run --quiet implied that using -q option alone would make the command wait until completion, which is incorrect.

Fixes #258