### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/dockers/install/apt/Dockerfile
+++ b/dockers/install/apt/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get -y update
-RUN apt-get -y install apt-transport-https curl
+RUN apt-get --no-install-recommends -y install apt-transport-https curl
 
 RUN echo "deb https://dl.bintray.com/rundeck/rundeck-deb /" | tee -a /etc/apt/sources.list
 
@@ -10,5 +10,5 @@ RUN apt-key add - < /tmp/bintray.gpg.key
 
 
 RUN apt-get -y update
-RUN apt-get install -y openjdk-8-jdk
-RUN apt-get -y install rundeck-cli
+RUN apt-get --no-install-recommends -y install openjdk-8-jdk
+RUN apt-get --no-install-recommends -y install rundeck-cli

--- a/dockers/install/debian/Dockerfile
+++ b/dockers/install/debian/Dockerfile
@@ -2,7 +2,7 @@ ARG VERS
 FROM ubuntu:${VERS:-16.04}
 
 RUN apt-get update
-RUN apt-get install -y openjdk-8-jdk
+RUN apt-get --no-install-recommends -y install openjdk-8-jdk
 RUN mkdir /root/.rd/
 COPY test-rd.conf /root/.rd/rd.conf
 COPY rundeck-cli_all.deb /root/rundeck-cli_all.deb

--- a/docs/install.md
+++ b/docs/install.md
@@ -71,9 +71,9 @@ via Bintray
 echo "deb https://dl.bintray.com/rundeck/rundeck-deb /" | sudo tee -a /etc/apt/sources.list
 curl "https://bintray.com/user/downloadSubjectPublicKey?username=bintray" > /tmp/bintray.gpg.key
 apt-key add - < /tmp/bintray.gpg.key
-apt-get -y install apt-transport-https
+apt-get --no-install-recommends -y install apt-transport-https
 apt-get -y update
-apt-get -y install rundeck-cli
+apt-get --no-install-recommends -y install rundeck-cli
 ~~~
 
 ### Arch Linux install


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>