### PR TITLE
Fix #323 indentation in verbose data output

### DIFF
--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/Main.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/Main.java
@@ -114,7 +114,7 @@ public class Main {
                 return super.format(o);
             }
         };
-        formatter.setCollectionIndicator("");
+        formatter.setCollectionIndicator("- ");
         belt.formatter(formatter);
         belt.channels().info(new FormattedOutput(
                 belt.defaultOutput(),


### PR DESCRIPTION
fix #323 using array char similar to yaml:

```
# 2 Jobs in project test3
- id: 4ed0ea80-cc42-4ace-b905-9f7ebd828a92
  name: child
  project: test3
  href: http://outatime.local:4440/api/35/job/4ed0ea80-cc42-4ace-b905-9f7ebd828a92
  permalink: http://outatime.local:4440/project/test3/job/show/4ed0ea80-cc42-4ace-b905-9f7ebd828a92
  description: 

- id: 31185ae0-f822-4749-b764-78950c6c323c
  name: parent
  project: test3
  href: http://outatime.local:4440/api/35/job/31185ae0-f822-4749-b764-78950c6c323c
  permalink: http://outatime.local:4440/project/test3/job/show/31185ae0-f822-4749-b764-78950c6c323c
  description: 
```