### PR TITLE
Revert "Fix #323 indentation in verbose data output"

### DIFF
--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/Main.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/Main.java
@@ -114,7 +114,7 @@ public class Main {
                 return super.format(o);
             }
         };
-        formatter.setCollectionIndicator("- ");
+        formatter.setCollectionIndicator("");
         belt.formatter(formatter);
         belt.channels().info(new FormattedOutput(
                 belt.defaultOutput(),


### PR DESCRIPTION
This reverts commit 92f399636c8b5474854da9b669d7ce171ea6b2ee.

Fix #332 