### PR TITLE
Enable extensions in shadow build

### DIFF
--- a/rd-api-client/src/main/java/org/rundeck/client/util/ConfigBase.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/ConfigBase.java
@@ -3,9 +3,26 @@ package org.rundeck.client.util;
 /**
  * Base for config sources
  */
-public abstract class ConfigBase
+public class ConfigBase
         implements ConfigSource
 {
+    final ConfigValues configSource;
+
+    public ConfigBase(final ConfigValues configSource) {
+        this.configSource = configSource;
+    }
+
+    @Override
+    public String get(final String key) {
+        return configSource.get(key);
+    }
+
+    @Override
+    public String getString(final String key, final String defval) {
+        String val = get(key);
+        return null == val ? defval : val;
+    }
+
     public int getInt(final String debug, final int defval) {
         String envProp = getString(debug, null);
         if (null != envProp) {
@@ -26,11 +43,6 @@ public abstract class ConfigBase
 
     public boolean getBool(final String key, final boolean defval) {
         return "true".equalsIgnoreCase(getString(key, defval ? "true" : "false"));
-    }
-
-    @Override
-    public String get(final String key) {
-        return getString(key, null);
     }
 
     public String require(final String name, final String description) throws ConfigSourceError {

--- a/rd-api-client/src/main/java/org/rundeck/client/util/ConfigBase.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/ConfigBase.java
@@ -1,0 +1,47 @@
+package org.rundeck.client.util;
+
+/**
+ * Base for config sources
+ */
+public abstract class ConfigBase
+        implements ConfigSource
+{
+    public int getInt(final String debug, final int defval) {
+        String envProp = getString(debug, null);
+        if (null != envProp) {
+            return Integer.parseInt(envProp);
+        } else {
+            return defval;
+        }
+    }
+
+    public Long getLong(final String key, final Long defval) {
+        String timeoutEnv = getString(key, null);
+        if (null != timeoutEnv) {
+            return Long.parseLong(timeoutEnv);
+        } else {
+            return defval;
+        }
+    }
+
+    public boolean getBool(final String key, final boolean defval) {
+        return "true".equalsIgnoreCase(getString(key, defval ? "true" : "false"));
+    }
+
+    @Override
+    public String get(final String key) {
+        return getString(key, null);
+    }
+
+    public String require(final String name, final String description) throws ConfigSourceError {
+        String value = get(name);
+        if (null == value) {
+            throw new ConfigSourceError(String.format(
+                    "Environment variable %s is required: %s",
+                    name,
+                    description
+            ));
+        }
+        return value;
+    }
+}

--- a/rd-api-client/src/main/java/org/rundeck/client/util/ConfigSource.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/ConfigSource.java
@@ -20,7 +20,7 @@ package org.rundeck.client.util;
  * @author greg
  * @since 1/11/17
  */
-public interface ConfigSource {
+public interface ConfigSource extends ConfigValues {
 
     int getInt(final String key, final int defval);
 
@@ -29,8 +29,6 @@ public interface ConfigSource {
     boolean getBool(final String key, final boolean defval);
 
     String getString(final String key, final String defval);
-
-    String get(final String key);
 
     String require(final String key, final String description) throws ConfigSourceError;
 

--- a/rd-api-client/src/main/java/org/rundeck/client/util/ConfigValues.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/ConfigValues.java
@@ -1,0 +1,8 @@
+package org.rundeck.client.util;
+
+/**
+ * Provides config values
+ */
+public interface ConfigValues {
+    String get(final String key);
+}

--- a/rd-api-client/src/main/java/org/rundeck/client/util/Env.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/Env.java
@@ -17,56 +17,16 @@
 package org.rundeck.client.util;
 
 /**
- * Configuration values from System.getenv
+ * Configuration values from System.getenv,
+ * keys will be converted to upper case, and "." replaced with "_".
  */
-public class Env implements ConfigSource {
-
-    public int getInt(final String debug, final int defval) {
-        String envProp = getString(debug, null);
-        if (null != envProp) {
-            return Integer.parseInt(envProp);
-        } else {
-            return defval;
-        }
-    }
-
-    public Long getLong(final String key, final Long defval) {
-        String timeoutEnv = getString(key, null);
-        if (null != timeoutEnv) {
-            return Long.parseLong(timeoutEnv);
-        } else {
-            return defval;
-        }
-    }
-
-    public boolean getBool(final String key, final boolean defval) {
-        return "true".equalsIgnoreCase(getString(key, defval ? "true" : "false"));
-    }
-
+public class Env extends ConfigBase implements ConfigSource {
     public String getString(final String key, final String defval) {
-        String val = System.getenv(key);
+        String val = System.getenv(key.toUpperCase().replaceAll("\\.", "_"));
         if (val != null) {
             return val;
         } else {
             return defval;
         }
     }
-
-    @Override
-    public String get(final String key) {
-        return getString(key, null);
-    }
-
-    public String require(final String name, final String description)  throws ConfigSourceError {
-        String value = System.getenv(name);
-        if (null == value) {
-            throw new ConfigSourceError(String.format(
-                    "Environment variable %s is required: %s",
-                    name,
-                    description
-            ));
-        }
-        return value;
-    }
-
 }

--- a/rd-api-client/src/main/java/org/rundeck/client/util/Env.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/Env.java
@@ -17,16 +17,22 @@
 package org.rundeck.client.util;
 
 /**
- * Configuration values from System.getenv,
- * keys will be converted to upper case, and "." replaced with "_".
+ * Configuration values from System.getenv, keys will be converted to upper case, and "." replaced with "_".
  */
-public class Env extends ConfigBase implements ConfigSource {
-    public String getString(final String key, final String defval) {
-        String val = System.getenv(key.toUpperCase().replaceAll("\\.", "_"));
-        if (val != null) {
-            return val;
-        } else {
-            return defval;
-        }
+public class Env
+        implements ConfigValues
+{
+    private Getenv getter = System::getenv;
+
+    public void setGetter(Getenv getter) {
+        this.getter = getter;
+    }
+
+    static interface Getenv {
+        public String getenv(final String key);
+    }
+
+    public String get(final String key) {
+        return getter.getenv(key.toUpperCase().replaceAll("\\.", "_"));
     }
 }

--- a/rd-api-client/src/main/java/org/rundeck/client/util/ExtConfigSource.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/ExtConfigSource.java
@@ -20,7 +20,10 @@ package org.rundeck.client.util;
  * @author greg
  * @since 1/11/17
  */
-public class ExtConfigSource implements ConfigSource {
+public class ExtConfigSource
+        extends ConfigBase
+        implements ConfigSource
+{
     final ConfigSource configSource;
 
     public ExtConfigSource(final ConfigSource configSource) {
@@ -28,32 +31,7 @@ public class ExtConfigSource implements ConfigSource {
     }
 
     @Override
-    public int getInt(final String key, final int defval) {
-        return configSource.getInt(key, defval);
-    }
-
-    @Override
-    public Long getLong(final String key, final Long defval) {
-        return configSource.getLong(key, defval);
-    }
-
-    @Override
-    public boolean getBool(final String key, final boolean defval) {
-        return configSource.getBool(key, defval);
-    }
-
-    @Override
     public String getString(final String key, final String defval) {
         return configSource.getString(key, defval);
-    }
-
-    @Override
-    public String get(final String key) {
-        return configSource.get(key);
-    }
-
-    @Override
-    public String require(final String key, final String description)  throws ConfigSourceError {
-        return configSource.require(key, description);
     }
 }

--- a/rd-api-client/src/main/java/org/rundeck/client/util/ExtConfigSource.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/ExtConfigSource.java
@@ -24,14 +24,12 @@ public class ExtConfigSource
         extends ConfigBase
         implements ConfigSource
 {
-    final ConfigSource configSource;
-
-    public ExtConfigSource(final ConfigSource configSource) {
-        this.configSource = configSource;
+    public ExtConfigSource(final ConfigValues configSource) {
+        super(configSource);
     }
 
     @Override
-    public String getString(final String key, final String defval) {
-        return configSource.getString(key, defval);
+    public String get(final String key) {
+        return configSource.get(key);
     }
 }

--- a/rd-api-client/src/main/java/org/rundeck/client/util/MapConfigValues.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/MapConfigValues.java
@@ -1,0 +1,21 @@
+package org.rundeck.client.util;
+
+import java.util.Map;
+
+/**
+ * Provides config values from a map
+ */
+public class MapConfigValues
+        implements ConfigValues
+{
+    private final Map<String, String> values;
+
+    public MapConfigValues(final Map<String, String> values) {
+        this.values = values;
+    }
+
+    @Override
+    public String get(final String key) {
+        return values.get(key);
+    }
+}

--- a/rd-api-client/src/main/java/org/rundeck/client/util/MultiConfigSource.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/MultiConfigSource.java
@@ -1,0 +1,34 @@
+package org.rundeck.client.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Returns first value from multiple sources
+ */
+public class MultiConfigSource
+        extends ConfigBase
+        implements ConfigSource
+{
+    private final List<ConfigSource> sources;
+
+    public MultiConfigSource(final List<ConfigSource> sources) {
+        this.sources = sources;
+    }
+
+    public MultiConfigSource(final ConfigSource... sources) {
+        this.sources = new ArrayList<>(Arrays.asList(sources));
+    }
+
+    @Override
+    public String getString(final String key, final String defval) {
+        for (ConfigSource source : sources) {
+            String val = source.get(key);
+            if (null != val) {
+                return val;
+            }
+        }
+        return defval;
+    }
+}

--- a/rd-api-client/src/main/java/org/rundeck/client/util/MultiConfigValues.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/MultiConfigValues.java
@@ -7,28 +7,27 @@ import java.util.List;
 /**
  * Returns first value from multiple sources
  */
-public class MultiConfigSource
-        extends ConfigBase
-        implements ConfigSource
+public class MultiConfigValues
+        implements ConfigValues
 {
-    private final List<ConfigSource> sources;
+    private final List<ConfigValues> sources;
 
-    public MultiConfigSource(final List<ConfigSource> sources) {
+    public MultiConfigValues(final List<ConfigValues> sources) {
         this.sources = sources;
     }
 
-    public MultiConfigSource(final ConfigSource... sources) {
+    public MultiConfigValues(final ConfigValues... sources) {
         this.sources = new ArrayList<>(Arrays.asList(sources));
     }
 
     @Override
-    public String getString(final String key, final String defval) {
-        for (ConfigSource source : sources) {
+    public String get(final String key) {
+        for (ConfigValues source : sources) {
             String val = source.get(key);
             if (null != val) {
                 return val;
             }
         }
-        return defval;
+        return null;
     }
 }

--- a/rd-api-client/src/main/java/org/rundeck/client/util/SysProps.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/SysProps.java
@@ -1,0 +1,14 @@
+package org.rundeck.client.util;
+
+/**
+ * Returns config value if it is defined in System properties,
+ * it will be converted to lowercase, and "_" replaced with ".".
+ */
+public class SysProps
+        extends ConfigBase
+        implements ConfigSource
+{
+    public String getString(final String key, final String defval) {
+        return System.getProperty(key.toLowerCase().replaceAll("_", "."), defval);
+    }
+}

--- a/rd-api-client/src/main/java/org/rundeck/client/util/SysProps.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/SysProps.java
@@ -1,14 +1,23 @@
 package org.rundeck.client.util;
 
 /**
- * Returns config value if it is defined in System properties,
- * it will be converted to lowercase, and "_" replaced with ".".
+ * Returns config value if it is defined in System properties, it will be converted to lowercase, and "_" replaced with
+ * ".".
  */
 public class SysProps
-        extends ConfigBase
-        implements ConfigSource
+        implements ConfigValues
 {
-    public String getString(final String key, final String defval) {
-        return System.getProperty(key.toLowerCase().replaceAll("_", "."), defval);
+    private GetProperty getter = System::getProperty;
+
+    public void setGetter(GetProperty getter) {
+        this.getter = getter;
+    }
+
+    static interface GetProperty {
+        public String getProperty(String key, String defval);
+    }
+
+    public String get(final String key) {
+        return getter.getProperty(key.toLowerCase().replaceAll("_", "."), null);
     }
 }

--- a/rd-api-client/src/test/groovy/org/rundeck/client/util/EnvSpec.groovy
+++ b/rd-api-client/src/test/groovy/org/rundeck/client/util/EnvSpec.groovy
@@ -1,0 +1,19 @@
+package org.rundeck.client.util
+
+import spock.lang.Specification
+
+class EnvSpec extends Specification {
+    def "env keys are uppercased"() {
+        given:
+            def env = new Env()
+            env.getter = { it }
+        expect:
+            expected == env.get(input)
+        where:
+            input        | expected
+            'a'          | 'A'
+            'a.b'        | 'A_B'
+            'some.value' | 'SOME_VALUE'
+            'SOME_VALUE' | 'SOME_VALUE'
+    }
+}

--- a/rd-api-client/src/test/groovy/org/rundeck/client/util/MultiConfigValuesSpec.groovy
+++ b/rd-api-client/src/test/groovy/org/rundeck/client/util/MultiConfigValuesSpec.groovy
@@ -1,0 +1,26 @@
+package org.rundeck.client.util
+
+import spock.lang.Specification
+
+class MultiConfigValuesSpec extends Specification {
+    def "multi value"() {
+        given:
+            def a = new MapConfigValues([a: 'b'])
+            def b = new MapConfigValues([b: 'c', a: 'z'])
+            def c = new MapConfigValues([b: 'q'])
+            def multi = new MultiConfigValues(a, b, c)
+
+        when:
+            def val = multi.get(input)
+
+        then:
+            val == expected
+
+        where:
+            input | expected
+            'a'   | 'b'
+            'b'   | 'c'
+            'c'   | null
+
+    }
+}

--- a/rd-api-client/src/test/groovy/org/rundeck/client/util/SysPropsSpec.groovy
+++ b/rd-api-client/src/test/groovy/org/rundeck/client/util/SysPropsSpec.groovy
@@ -1,0 +1,22 @@
+package org.rundeck.client.util
+
+import spock.lang.Specification
+
+class SysPropsSpec extends Specification {
+    def "keys lowercased"() {
+        given:
+            SysProps props = new SysProps()
+            props.getter = { a, b ->
+                a
+            }
+        expect:
+            expected == props.get(input)
+
+        where:
+            input           | expected
+            'a'             | 'a'
+            'a.b'           | 'a.b'
+            'A_B'           | 'a.b'
+            'SOME_PROP_KEY' | 'some.prop.key'
+    }
+}

--- a/rd-cli-tool/build.gradle
+++ b/rd-cli-tool/build.gradle
@@ -25,9 +25,8 @@ buildscript {
 plugins {
     id 'groovy'
     id 'application'
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
+    id 'com.github.johnrengelman.shadow' version '6.0.0'
     id "nebula.ospackage" version "8.1.0"
-
 }
 
 apply plugin: 'idea'

--- a/rd-cli-tool/build.gradle
+++ b/rd-cli-tool/build.gradle
@@ -97,11 +97,7 @@ set -e
 # Source user's config file
 RD_CONF=${RD_CONF:-$HOME/.$APP_NAME/$APP_NAME.conf}
 test -f $RD_CONF && . $RD_CONF
-RD_EXT_DIR=${RD_EXT_DIR:-$HOME/.$APP_NAME/ext/}
-
-if [ -n "$RD_EXT_DIR" ] && [ -d "$RD_EXT_DIR" ] ; then
-  CLASSPATH=${CLASSPATH}:$RD_EXT_DIR/*
-fi
+export RD_EXT_DIR=${RD_EXT_DIR:-$HOME/.$APP_NAME/ext}
 '''
     )
 

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/Main.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/Main.java
@@ -29,6 +29,7 @@ import org.rundeck.client.tool.util.AdaptedToolbeltOutput;
 import org.rundeck.client.tool.util.ExtensionLoaderUtil;
 import org.rundeck.client.tool.util.Resources;
 import org.rundeck.client.util.*;
+import org.rundeck.client.util.DataOutput;
 import org.rundeck.toolbelt.*;
 import org.rundeck.toolbelt.format.json.jackson.JsonFormatter;
 import org.rundeck.toolbelt.format.yaml.snakeyaml.YamlFormatter;
@@ -45,31 +46,33 @@ import java.net.URLClassLoader;
 import java.util.*;
 import java.util.function.Function;
 
-import static org.rundeck.client.RundeckClient.ENV_INSECURE_SSL;
-import static org.rundeck.client.RundeckClient.ENV_INSECURE_SSL_NO_WARN;
+import static org.rundeck.client.RundeckClient.*;
 
 
 /**
  * Entrypoint for commandline
  */
 public class Main {
+    public static final String RD_USER = "RD_USER";
+    public static final String RD_PASSWORD = "RD_PASSWORD";
+    public static final String RD_TOKEN = "RD_TOKEN";
+    public static final String RD_URL = "RD_URL";
+    public static final String RD_API_VERSION = "RD_API_VERSION";
+    public static final String RD_AUTH_PROMPT = "RD_AUTH_PROMPT";
+    public static final String RD_DEBUG = "RD_DEBUG";
+    public static final String RD_FORMAT = "RD_FORMAT";
+    public static final String RD_EXT_DISABLED = "RD_EXT_DISABLED";
+    public static final String RD_EXT_DIR = "RD_EXT_DIR";
 
-    public static final String ENV_USER          = "RD_USER";
-    public static final String ENV_PASSWORD      = "RD_PASSWORD";
-    public static final String ENV_TOKEN         = "RD_TOKEN";
-    public static final String ENV_URL           = "RD_URL";
-    public static final String ENV_API_VERSION   = "RD_API_VERSION";
-    public static final String ENV_AUTH_PROMPT   = "RD_AUTH_PROMPT";
-    public static final String ENV_DEBUG         = "RD_DEBUG";
-    public static final String ENV_RD_FORMAT     = "RD_FORMAT";
     public static final String
             USER_AGENT =
             RundeckClient.Builder.getUserAgent("rd-cli-tool/" + org.rundeck.client.Version.VERSION);
 
     public static void main(String[] args) throws CommandRunFailure {
         boolean success = false;
-        loadExtensionJars();
-        try (Rd rd = new Rd(new Env())) {
+        ConfigSource config = buildConfig();
+        loadExtensionJars(config);
+        try (Rd rd = new Rd(config)) {
             Tool tool = tool(rd);
             try {
                 success = tool.runMain(args, false);
@@ -89,8 +92,15 @@ public class Main {
         }
     }
 
-    private static void loadExtensionJars() {
-        String rd_ext_dir = System.getenv("RD_EXT_DIR");
+    private static ConfigSource buildConfig() {
+        return new MultiConfigSource(new Env(), new SysProps());
+    }
+
+    private static void loadExtensionJars(ConfigSource config) {
+        if (config.getBool(RD_EXT_DISABLED, false)) {
+            return;
+        }
+        String rd_ext_dir = config.get(RD_EXT_DIR);
         if(null==rd_ext_dir){
             return;
         }
@@ -122,14 +132,14 @@ public class Main {
     }
 
     private static void setupFormat(final ToolBelt belt, RdClientConfig config) {
-        final String format = config.get(ENV_RD_FORMAT);
+        final String format = config.get(RD_FORMAT);
         if ("yaml".equalsIgnoreCase(format)) {
             configYamlFormat(belt, config);
         } else if ("json".equalsIgnoreCase(format)) {
             configJsonFormat(belt);
         } else {
             if (null != format) {
-                belt.finalOutput().warning(String.format("# WARNING: Unknown value for %s: %s", ENV_RD_FORMAT, format));
+                belt.finalOutput().warning(String.format("# WARNING: Unknown value for %s: %s", RD_FORMAT, format));
             }
             configNiceFormat(belt);
         }
@@ -238,11 +248,8 @@ public class Main {
         setupColor(belt, rd);
         setupFormat(belt, rd);
 
-        boolean insecureSsl = Boolean.parseBoolean(System.getProperty(
-                "rundeck.client.insecure.ssl",
-                System.getenv(ENV_INSECURE_SSL)
-        ));
-        boolean insecureSslNoWarn = Boolean.parseBoolean(System.getenv(ENV_INSECURE_SSL_NO_WARN));
+        boolean insecureSsl = rd.getBool(ENV_INSECURE_SSL, false);
+        boolean insecureSslNoWarn = rd.getBool(ENV_INSECURE_SSL_NO_WARN, false);
         if (insecureSsl && !insecureSslNoWarn ) {
             belt.finalOutput().warning(
                     "# WARNING: RD_INSECURE_SSL=true, no hostname or certificate trust verification will be performed");
@@ -293,7 +300,7 @@ public class Main {
 
         @Override
         public int getDebugLevel() {
-            return getInt(ENV_DEBUG, 0);
+            return getInt(RD_DEBUG, 0);
         }
 
         public String getDateFormat() {
@@ -419,11 +426,11 @@ public class Main {
         };
         auth = auth.chain(new ConfigAuth(config));
         String baseUrl = config.require(
-                ENV_URL,
+                RD_URL,
                 "Please specify the Rundeck base URL, e.g. http://host:port or http://host:port/api/14"
         );
 
-        if (!auth.isConfigured() && config.getBool(ENV_AUTH_PROMPT, true) && null != System.console()) {
+        if (!auth.isConfigured() && config.getBool(RD_AUTH_PROMPT, true) && null != System.console()) {
             auth = auth.chain(new ConsoleAuth(String.format("Credentials for URL: %s", baseUrl)).memoize());
         }
         RundeckClient.Builder<T> builder = RundeckClient.builder(api)
@@ -432,7 +439,7 @@ public class Main {
         if (null != requestedVersion) {
             builder.apiVersion(requestedVersion);
         } else {
-            int anInt = config.getInt(ENV_API_VERSION, -1);
+            int anInt = config.getInt(RD_API_VERSION, -1);
             if (anInt > 0) {
                 builder.apiVersion(anInt);
             }
@@ -443,11 +450,11 @@ public class Main {
         } else {
             if (null == auth.getUsername() || "".equals(auth.getUsername().trim())) {
                 throw new IllegalArgumentException("Username or token must be entered, or use environment variable " +
-                                                   ENV_USER + " or " + ENV_TOKEN);
+                                                   RD_USER + " or " + RD_TOKEN);
             }
             if (null == auth.getPassword() || "".equals(auth.getPassword().trim())) {
                 throw new IllegalArgumentException("Password must be entered, or use environment variable " +
-                                                   ENV_PASSWORD);
+                                                   RD_PASSWORD);
             }
             builder.passwordAuth(auth.getUsername(), auth.getPassword());
         }
@@ -504,17 +511,17 @@ public class Main {
 
         @Override
         public String getUsername() {
-            return config.get(ENV_USER);
+            return config.get(RD_USER);
         }
 
         @Override
         public String getPassword() {
-            return config.get(ENV_PASSWORD);
+            return config.get(RD_PASSWORD);
         }
 
         @Override
         public String getToken() {
-            return config.get(ENV_TOKEN);
+            return config.get(RD_TOKEN);
         }
     }
 

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/Main.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/Main.java
@@ -93,7 +93,7 @@ public class Main {
     }
 
     private static ConfigSource buildConfig() {
-        return new MultiConfigSource(new Env(), new SysProps());
+        return new ConfigBase(new MultiConfigValues(new Env(), new SysProps()));
     }
 
     private static void loadExtensionJars(ConfigSource config) {
@@ -278,12 +278,12 @@ public class Main {
         return belt.buckle();
     }
 
-    static class Rd extends ExtConfigSource implements RdApp, RdClientConfig, Closeable {
+    static class Rd extends ConfigBase implements RdApp, RdClientConfig, Closeable {
         private final Resources resources = new Resources();
         Client<RundeckApi> client;
         private CommandOutput output;
 
-        public Rd(final ConfigSource src) {
+        public Rd(final ConfigValues src) {
             super(src);
         }
 


### PR DESCRIPTION
- [x] fix: if RD_EXT_DIR is set, rd fails to run when using shadow jar/shadow dist (rpm,deb)
- [x] refactor: extension loading happens internally instead of relying on classpath set on JVM commandline
- [x] refactor: some cleanup around reading config values from ENV