### PR TITLE
Fix #352 node attribute expansion not working for ssh-xyz attributes

### DIFF
--- a/rd-api-client/src/main/java/org/rundeck/client/util/Format.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/Format.java
@@ -35,7 +35,7 @@ public class Format {
     }
 
     public static String format(String format, Map<?, ?> data, final String start, final String end) {
-        Pattern pat = Pattern.compile(Pattern.quote(start) + "([\\w.]+)" + Pattern.quote(end));
+        Pattern pat = Pattern.compile(Pattern.quote(start) + "([\\w.:_-]+)" + Pattern.quote(end));
         Matcher matcher = pat.matcher(format);
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {

--- a/rd-api-client/src/main/java/org/rundeck/client/util/Format.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/util/Format.java
@@ -35,7 +35,7 @@ public class Format {
     }
 
     public static String format(String format, Map<?, ?> data, final String start, final String end) {
-        Pattern pat = Pattern.compile(Pattern.quote(start) + "([\\w.:_-]+)" + Pattern.quote(end));
+        Pattern pat = Pattern.compile(Pattern.quote(start) + "([\\w._-]+)" + Pattern.quote(end));
         Matcher matcher = pat.matcher(format);
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {

--- a/rd-cli-tool/src/test/groovy/org/rundeck/client/util/FormatSpec.groovy
+++ b/rd-cli-tool/src/test/groovy/org/rundeck/client/util/FormatSpec.groovy
@@ -39,7 +39,6 @@ class FormatSpec extends Specification {
         '%'   | ''  | 'a %b %c'     | [b: '\\x'] | 'a \\x '
         '%'   | ''  | 'a %b-x q'    | ['b-x': 'z'] | 'a z q'
         '%'   | ''  | 'a %b_x r'    | ['b_x': 'z'] | 'a z r'
-        '%'   | ''  | 'a %b:x r'    | ['b:x': 'z'] | 'a z r'
 
     }
 
@@ -58,7 +57,6 @@ class FormatSpec extends Specification {
         '%'   | ''  | '%a.b b c'     | [a: 'x', b: [c: 'd']] | ' b c'
         '%'   | ''  | '%b.c-d q r'     | [a: 'x', b: ['c-d': 'e']] | 'e q r'
         '%'   | ''  | '%b.c_d q r'     | [a: 'x', b: ['c_d': 'e']] | 'e q r'
-        '%'   | ''  | '%b.c:d q r'     | [a: 'x', b: ['c:d': 'e']] | 'e q r'
 
     }
 }

--- a/rd-cli-tool/src/test/groovy/org/rundeck/client/util/FormatSpec.groovy
+++ b/rd-cli-tool/src/test/groovy/org/rundeck/client/util/FormatSpec.groovy
@@ -37,6 +37,9 @@ class FormatSpec extends Specification {
         '%'   | ''  | 'a %b %c'     | [b: 'x']   | 'a x '
         '%'   | ''  | 'a %b %c'     | [b: '$x']  | 'a $x '
         '%'   | ''  | 'a %b %c'     | [b: '\\x'] | 'a \\x '
+        '%'   | ''  | 'a %b-x q'    | ['b-x': 'z'] | 'a z q'
+        '%'   | ''  | 'a %b_x r'    | ['b_x': 'z'] | 'a z r'
+        '%'   | ''  | 'a %b:x r'    | ['b:x': 'z'] | 'a z r'
 
     }
 
@@ -52,6 +55,10 @@ class FormatSpec extends Specification {
         '${'  | '}' | '${b.c} b c'   | [a: 'x', b: [c: 'd']] | 'd b c'
         '${'  | '}' | '${b.DNE} b c' | [a: 'x', b: [c: 'd']] | ' b c'
         '${'  | '}' | '${a.b} b c'   | [a: 'x', b: [c: 'd']] | ' b c'
+        '%'   | ''  | '%a.b b c'     | [a: 'x', b: [c: 'd']] | ' b c'
+        '%'   | ''  | '%b.c-d q r'     | [a: 'x', b: ['c-d': 'e']] | 'e q r'
+        '%'   | ''  | '%b.c_d q r'     | [a: 'x', b: ['c_d': 'e']] | 'e q r'
+        '%'   | ''  | '%b.c:d q r'     | [a: 'x', b: ['c:d': 'e']] | 'e q r'
 
     }
 }


### PR DESCRIPTION
* support `_-` chars in output format key names

fixes #352 

* note: I originally added support for `:` char as well, however it broke a testcase like `%id:%token`. I think adding `:` makes sense in the node output case because node attributes do use `:` char, but we need to add another syntax that would allow the `%id:%token` to still work, something like `${id}:${token}` or `%{id}:%{token}` with a suffix in the syntax. I am not addressing that in this bug fix, it will have to be a future enhancement.