### PR TITLE
token create: help output update

### DIFF
--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Tokens.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Tokens.java
@@ -58,7 +58,7 @@ public class Tokens extends BaseCommand {
 
         @CommandLine.Option(names = {"--roles", "-r"},
                 arity = "1..*",
-                description = "List of roles to set for the token, space separated (api v19+)")
+                description = "List of roles to set for the token, comma separated (api v41+)")
         List<String> roles;
 
         boolean isRoles() {

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Tokens.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Tokens.java
@@ -58,7 +58,7 @@ public class Tokens extends BaseCommand {
 
         @CommandLine.Option(names = {"--roles", "-r"},
                 arity = "1..*",
-                description = "List of roles to set for the token, comma separated (api v41+)")
+                description = "List of roles to set for the token, comma separated (api v19+)")
         List<String> roles;
 
         boolean isRoles() {


### PR DESCRIPTION
Related to issue: #480 
- update to token create subcommand's help output to reference comma delim rather than space delim.   
- functionality verified with rd cli v2.0.3, rundeck enterprise v4.5.0-20220811, and API v41