### PR TITLE
RUN-1490: Correct suggested import component

### DIFF
--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/projects/Archives.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/projects/Archives.java
@@ -102,7 +102,7 @@ public class Archives extends BaseCommand  {
         @CommandLine.Option(
                 names = {"--component", "-I"},
                 arity = "0..*",
-                description = "Enable named import components, such as project-tours (enterprise)")
+                description = "Enable named import components, such as tours-manager (enterprise). See <https://docs.rundeck.com/docs/api/rundeck-api.html#project-archive-import>")
         Set<String> components;
 
         @CommandLine.Option(


### PR DESCRIPTION
Use correct name for project tours import component, and link to API docs.

Note: API docs PR to fix project tours import component name is here: https://github.com/rundeck/docs/pull/1174