### PR TITLE
RUN-1634: Fix exit codes on command failures

### DIFF
--- a/rd-cli-acl/src/main/java/org/rundeck/client/ext/acl/Acl.java
+++ b/rd-cli-acl/src/main/java/org/rundeck/client/ext/acl/Acl.java
@@ -477,9 +477,9 @@ public class Acl
     }
 
     @CommandLine.Command(description = "Test ACL Policies")
-    public boolean test(@CommandLine.Mixin TestOptions opts)  {
+    public int test(@CommandLine.Mixin TestOptions opts)  {
         if (!applyArgValidate(opts)) {
-            return false;
+            return 2;
         }
         final RuleEvaluator authorization = createAuthorization(opts);
         AuthRequest authRequest = createAuthRequestFromArgs(opts);
@@ -562,7 +562,7 @@ public class Acl
             );
         }
         log("The test " + (testPassed ? "passed" : "failed"));
-        return testPassed;
+        return testPassed?0:2;
     }
 
     @CommandLine.Command(description = "Create ACL Policies")
@@ -580,11 +580,11 @@ public class Acl
     }
 
     @CommandLine.Command(description = "Validate ACL Policies")
-    public boolean validate(@CommandLine.Mixin AclOptions opts) {
+    public int validate(@CommandLine.Mixin AclOptions opts) {
         final Validation validation = validatePolicies(opts);
         reportValidation(validation);
         log("The validation " + (validation.isValid() ? "passed" : "failed"));
-        return validation.isValid();
+        return validation.isValid() ? 0 : 2;
     }
 
     private HashSet<Map<String, String>> resources(final Map<String, String> resourceMap) {

--- a/rd-cli-base/src/main/java/org/rundeck/client/tool/commands/repository/InstallPlugin.java
+++ b/rd-cli-base/src/main/java/org/rundeck/client/tool/commands/repository/InstallPlugin.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(description = "Install a plugin from your plugin repository into your Rundeck instance", name = "install")
-public class InstallPlugin implements RdCommandExtension, RdOutput, Callable<Boolean> {
+public class InstallPlugin implements RdCommandExtension, RdOutput, Callable<Integer> {
     @Setter
     private RdTool rdTool;
 
@@ -40,7 +40,7 @@ public class InstallPlugin implements RdCommandExtension, RdOutput, Callable<Boo
     @CommandLine.Option(names = {"--version", "-v"}, description = "(Optional) Specific version of the plugin you want to install")
     String version;
 
-    public Boolean call() throws InputError, IOException {
+    public Integer call() throws InputError, IOException {
         RepositoryResponseHandler.handle(
                 rdTool.apiWithErrorResponse(api -> {
                     if (version != null) {
@@ -49,7 +49,7 @@ public class InstallPlugin implements RdCommandExtension, RdOutput, Callable<Boo
                         return api.installPlugin(repoName, pluginId);
                     }
                 }), rdOutput);
-        return true;
+        return 0;
     }
 
 }

--- a/rd-cli-base/src/main/java/org/rundeck/client/tool/commands/repository/UninstallPlugin.java
+++ b/rd-cli-base/src/main/java/org/rundeck/client/tool/commands/repository/UninstallPlugin.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(description = "Unistall a Rundeck plugin from your Rundeck instance", name = "uninstall")
-public class UninstallPlugin implements Callable<Boolean>, RdCommandExtension, RdOutput {
+public class UninstallPlugin implements Callable<Integer>, RdCommandExtension, RdOutput {
     @Setter
     private RdTool rdTool;
     @Setter
@@ -38,10 +38,10 @@ public class UninstallPlugin implements Callable<Boolean>, RdCommandExtension, R
     String pluginId;
 
 
-    public Boolean call() throws InputError, IOException {
+    public Integer call() throws InputError, IOException {
         RepositoryResponseHandler.handle(
                 rdTool.apiWithErrorResponse(api -> api.uninstallPlugin(pluginId)), rdOutput
         );
-        return true;
+        return 0;
     }
 }

--- a/rd-cli-base/src/main/java/org/rundeck/client/tool/commands/repository/UploadPlugin.java
+++ b/rd-cli-base/src/main/java/org/rundeck/client/tool/commands/repository/UploadPlugin.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(description = "Upload a Rundeck plugin to your plugin repository", name = "upload")
-public class UploadPlugin extends BaseCommand implements Callable<Boolean> {
+public class UploadPlugin extends BaseCommand implements Callable<Integer> {
 
     @CommandLine.Option(names = {"-r", "--repository"}, description = "Target name of repository to upload plugin into.", required = true)
     String repoName;
@@ -35,13 +35,13 @@ public class UploadPlugin extends BaseCommand implements Callable<Boolean> {
     String binaryPath;
 
 
-    public Boolean call() throws InputError, IOException {
+    public Integer call() throws InputError, IOException {
         File binary = new File(binaryPath);
         if (!binary.exists())
             throw new IOException(String.format("Unable to find specified file: %s", binaryPath));
         RequestBody fileUpload = RequestBody.create(binary, Client.MEDIA_TYPE_OCTET_STREAM);
 
         RepositoryResponseHandler.handle(getRdTool().apiWithErrorResponse(api -> api.uploadPlugin(repoName, fileUpload)), getRdOutput());
-        return true;
+        return 0;
     }
 }

--- a/rd-cli-base/src/test/groovy/org/rundeck/client/tool/commands/repository/InstallPluginTest.groovy
+++ b/rd-cli-base/src/test/groovy/org/rundeck/client/tool/commands/repository/InstallPluginTest.groovy
@@ -46,10 +46,11 @@ class InstallPluginTest extends Specification {
         installCmd.pluginId = 'bcf8885df1e8'
 
         when:
-        installCmd.call()
+        def result = installCmd.call()
 
         then:
         1 * api.installPlugin("private", 'bcf8885df1e8') >> Calls.response(new ArtifactActionMessage(msg: "Plugin Installed"))
         1 * out.output('Plugin Installed')
+        result == 0
     }
 }

--- a/rd-cli-base/src/test/groovy/org/rundeck/client/tool/commands/repository/UninstallPluginTest.groovy
+++ b/rd-cli-base/src/test/groovy/org/rundeck/client/tool/commands/repository/UninstallPluginTest.groovy
@@ -43,10 +43,11 @@ class UninstallPluginTest extends Specification {
 
 
         when:
-        uninstallCmd.call()
+        def result=uninstallCmd.call()
 
         then:
         1 * api.uninstallPlugin(_) >> Calls.response(new ArtifactActionMessage(msg: "Plugin Uninstalled"))
         1 * out.output('Plugin Uninstalled')
+        result==0
     }
 }

--- a/rd-cli-base/src/test/groovy/org/rundeck/client/tool/commands/repository/UploadPluginTest.groovy
+++ b/rd-cli-base/src/test/groovy/org/rundeck/client/tool/commands/repository/UploadPluginTest.groovy
@@ -47,10 +47,11 @@ class UploadPluginTest extends Specification {
 
 
         when:
-        uploadCmd.call()
+        def result = uploadCmd.call()
 
         then:
         1 * api.uploadPlugin("private", _) >> Calls.response(new ArtifactActionMessage(msg: "Upload succeeded"))
         1 * out.output('Upload succeeded')
+        result == 0
     }
 }

--- a/rd-cli-enterprise/build.gradle
+++ b/rd-cli-enterprise/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation libs.picocli
     annotationProcessor libs.picocliCodegen
 
-    testImplementation project(":rd-cli-lib"), project(":rd-api-client")
+    testImplementation project(":rd-cli-lib"), project(":rd-api-client"), project(":rd-testing")
 
     testImplementation libs.retrofitMock
     testImplementation libs.okhttpMockwebserver

--- a/rd-cli-enterprise/src/main/java/org/rundeck/client/tool/commands/enterprise/cluster/Mode.java
+++ b/rd-cli-enterprise/src/main/java/org/rundeck/client/tool/commands/enterprise/cluster/Mode.java
@@ -28,14 +28,14 @@ public class Mode extends BaseExtension {
     }
 
     @CommandLine.Command(description = "Set cluster member execution mode Active")
-    public boolean active(@CommandLine.Mixin Options options) throws IOException, InputError {
-        return changeMode(ExecutionMode.active, options, EnterpriseApi::executionModeEnable);
+    public int active(@CommandLine.Mixin Options options) throws IOException, InputError {
+        return changeMode(ExecutionMode.active, options, EnterpriseApi::executionModeEnable) ? 0 : 1;
     }
 
 
     @CommandLine.Command(description = "Set cluster member execution mode Passive")
-    public boolean passive(@CommandLine.Mixin Options options) throws IOException, InputError {
-        return changeMode(ExecutionMode.passive, options, EnterpriseApi::executionModeDisable);
+    public int passive(@CommandLine.Mixin Options options) throws IOException, InputError {
+        return changeMode(ExecutionMode.passive, options, EnterpriseApi::executionModeDisable) ? 0 : 1;
     }
 
     boolean changeMode(

--- a/rd-cli-enterprise/src/main/java/org/rundeck/client/tool/commands/enterprise/license/License.java
+++ b/rd-cli-enterprise/src/main/java/org/rundeck/client/tool/commands/enterprise/license/License.java
@@ -50,7 +50,7 @@ public class License
     }
 
     @CommandLine.Command(description = "license status")
-    public boolean status(@CommandLine.Mixin StatusOpts opts) throws InputError, IOException {
+    public int status(@CommandLine.Mixin StatusOpts opts) throws InputError, IOException {
         RdTool.apiVersionCheck("license status", 41, getClient().getApiVersion());
         LicenseResponse response = getClient().apiCall(EnterpriseApi::verifyLicense);
 
@@ -85,9 +85,9 @@ public class License
                         opts.getRemaining()
                 ));
             }
-            return false;
+            return 1;
         }
-        return !opts.isStatus() || response.isActive();
+        return (!opts.isStatus() || response.isActive()) ? 0 : 1;
     }
 
 

--- a/rd-cli-enterprise/src/test/groovy/org/rundeck/client/tool/commands/enterprise/cluster/ModeSpec.groovy
+++ b/rd-cli-enterprise/src/test/groovy/org/rundeck/client/tool/commands/enterprise/cluster/ModeSpec.groovy
@@ -1,0 +1,77 @@
+package org.rundeck.client.tool.commands.enterprise.cluster
+
+import groovy.transform.CompileStatic
+import org.rundeck.client.api.model.ExecutionMode
+import org.rundeck.client.testing.MockRdTool
+import org.rundeck.client.tool.CommandOutput
+import org.rundeck.client.tool.RdApp
+import org.rundeck.client.tool.commands.enterprise.api.EnterpriseApi
+import org.rundeck.client.tool.commands.enterprise.api.model.EnterpriseModeResponse
+import org.rundeck.client.tool.commands.enterprise.api.model.LicenseResponse
+import org.rundeck.client.tool.commands.enterprise.license.License
+import org.rundeck.client.tool.extension.RdTool
+import org.rundeck.client.util.Client
+import org.rundeck.client.util.RdClientConfig
+import retrofit2.Retrofit
+import retrofit2.mock.Calls
+import spock.lang.Specification
+
+class ModeSpec extends Specification {
+    private RdTool setupMock(EnterpriseApi api, CommandOutput out, int apiVersion) {
+        def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
+        def client = new Client(api, retrofit, null, null, apiVersion, true, null)
+        def rdapp = Mock(RdApp) {
+            getClient(EnterpriseApi) >> client
+            getAppConfig() >> Mock(RdClientConfig)
+            getOutput() >> out
+        }
+        def rdTool = new MockRdTool(client: client, rdApp: rdapp)
+        rdTool.appConfig = Mock(RdClientConfig)
+        rdTool
+    }
+
+    def "active"() {
+        def api = Mock(EnterpriseApi)
+        def out = Mock(CommandOutput)
+        RdTool rdTool = setupMock(api, out, 41)
+        Mode command = new Mode()
+        command.rdTool = rdTool
+        def opts = new Mode.Options()
+        opts.uuid = 'uuid'
+
+
+        when:
+        def result = command.active(opts)
+
+        then:
+        1 * api.executionModeEnable('uuid') >> Calls.response(new EnterpriseModeResponse(executionMode: respstatus as ExecutionMode))
+        0 * api._(*_)
+        result == expected
+        where:
+        respstatus | expected
+        'active'   | 0
+        'passive'  | 1
+    }
+    def "passive"() {
+        def api = Mock(EnterpriseApi)
+        def out = Mock(CommandOutput)
+        RdTool rdTool = setupMock(api, out, 41)
+        Mode command = new Mode()
+        command.rdTool = rdTool
+        def opts = new Mode.Options()
+        opts.uuid = 'uuid'
+
+
+        when:
+        def result = command.passive(opts)
+
+        then:
+        1 * api.executionModeDisable('uuid') >> Calls.response(new EnterpriseModeResponse(executionMode: respstatus as ExecutionMode))
+        0 * api._(*_)
+        result == expected
+        where:
+        respstatus | expected
+        'active'   | 1
+        'passive'  | 0
+    }
+}

--- a/rd-cli-enterprise/src/test/groovy/org/rundeck/client/tool/commands/enterprise/license/LicenseSpec.groovy
+++ b/rd-cli-enterprise/src/test/groovy/org/rundeck/client/tool/commands/enterprise/license/LicenseSpec.groovy
@@ -1,0 +1,97 @@
+package org.rundeck.client.tool.commands.enterprise.license
+
+import groovy.transform.CompileStatic
+import okhttp3.ResponseBody
+import org.rundeck.client.api.RundeckApi
+import org.rundeck.client.api.model.KeyStorageItem
+import org.rundeck.client.testing.MockRdTool
+import org.rundeck.client.tool.CommandOutput
+import org.rundeck.client.tool.RdApp
+import org.rundeck.client.tool.commands.enterprise.api.EnterpriseApi
+import org.rundeck.client.tool.commands.enterprise.api.model.LicenseResponse
+import org.rundeck.client.tool.extension.RdTool
+import org.rundeck.client.util.Client
+import org.rundeck.client.util.RdClientConfig
+import retrofit2.Retrofit
+import retrofit2.mock.Calls
+import spock.lang.Specification
+
+class LicenseSpec extends Specification {
+    private RdTool setupMock(EnterpriseApi api, CommandOutput out, int apiVersion) {
+        def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
+        def client = new Client(api, retrofit, null, null, apiVersion, true, null)
+        def rdapp = Mock(RdApp) {
+            getClient(EnterpriseApi) >> client
+            getAppConfig() >> Mock(RdClientConfig)
+            getOutput() >> out
+        }
+        def rdTool = new MockRdTool(client: client, rdApp: rdapp)
+        rdTool.appConfig = Mock(RdClientConfig)
+        rdTool
+    }
+
+    def "status"() {
+        def api = Mock(EnterpriseApi)
+        def out = Mock(CommandOutput)
+        RdTool rdTool = setupMock(api, out, 41)
+        License command = new License()
+        command.rdTool = rdTool
+        def opts = new License.StatusOpts()
+
+
+        when:
+        def result = command.status(opts)
+
+        then:
+        1 * api.verifyLicense() >> Calls.response(new LicenseResponse())
+        0 * api._(*_)
+        result == 0
+    }
+
+    def "status remaining"() {
+        def api = Mock(EnterpriseApi)
+        def out = Mock(CommandOutput)
+        RdTool rdTool = setupMock(api, out, 41)
+        License command = new License()
+        command.rdTool = rdTool
+        def opts = new License.StatusOpts()
+        opts.remaining = optremain
+
+
+        when:
+        def result = command.status(opts)
+
+        then:
+        1 * api.verifyLicense() >> Calls.response(new LicenseResponse(remaining: remaining))
+        0 * api._(*_)
+        result == expect
+        where:
+        optremain | remaining | expect
+        10        | 10        | 0
+        10        | 9         | 1
+        10        | 0         | 1
+    }
+
+    def "status expired"() {
+        def api = Mock(EnterpriseApi)
+        def out = Mock(CommandOutput)
+        RdTool rdTool = setupMock(api, out, 41)
+        License command = new License()
+        command.rdTool = rdTool
+        def opts = new License.StatusOpts()
+        opts.status = true
+
+
+        when:
+        def result = command.status(opts)
+
+        then:
+        1 * api.verifyLicense() >> Calls.response(new LicenseResponse(active: active))
+        0 * api._(*_)
+        result == expect
+        where:
+        active | expect
+        true   | 0
+        false  | 1
+    }
+}

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Adhoc.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Adhoc.java
@@ -40,7 +40,7 @@ import java.util.stream.Stream;
  */
 
 @CommandLine.Command(description = "Run adhoc command or script on matching nodes.", name = "adhoc", showEndOfOptionsDelimiterInUsageHelp = true)
-public class Adhoc extends BaseCommand implements Callable<Boolean> {
+public class Adhoc extends BaseCommand implements Callable<Integer> {
 
     @CommandLine.Mixin
     AdhocBaseOptions options;
@@ -51,7 +51,7 @@ public class Adhoc extends BaseCommand implements Callable<Boolean> {
     @CommandLine.Mixin
     NodeFilterBaseOptions nodeFilterOptions;
 
-    public Boolean call() throws IOException, InputError {
+    public Integer call() throws IOException, InputError {
         AdhocResponse adhocResponse;
 
         String project = getRdTool().projectOrEnv(options);
@@ -135,7 +135,7 @@ public class Adhoc extends BaseCommand implements Callable<Boolean> {
             );
         }
 
-        return Executions.maybeFollow(getRdTool(), followOptions, outputFormatOption, adhocResponse.execution.getId(), getRdOutput());
+        return Executions.maybeFollow(getRdTool(), followOptions, outputFormatOption, adhocResponse.execution.getId(), getRdOutput()) ? 0 : 1;
     }
 
 }

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Executions.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Executions.java
@@ -568,7 +568,7 @@ public class Executions extends BaseCommand {
 
     @CommandLine.Command(description = "Find and delete executions in a project. Use the query options to find and delete " +
             "executions, or specify executions with the `idlist` option.")
-    public boolean deletebulk(@CommandLine.Mixin BulkDeleteCmd options,
+    public int deletebulk(@CommandLine.Mixin BulkDeleteCmd options,
                               @CommandLine.Mixin PagingResultOptions paging,
                               @CommandLine.Mixin ExecutionOutputFormatOption outputFormatOption) throws IOException, InputError {
 
@@ -588,7 +588,7 @@ public class Executions extends BaseCommand {
                 } else {
                     getRdOutput().warning("No executions found to delete");
                 }
-                return !options.isRequire();
+                return options.isRequire()?2:0;
             }
         }
 
@@ -598,7 +598,7 @@ public class Executions extends BaseCommand {
 
             if (!"y".equals(s)) {
                 getRdOutput().warning("Not deleting executions.");
-                return false;
+                return 1;
             }
         }
         final List<String> finalExecIds = execIds;
@@ -613,7 +613,7 @@ public class Executions extends BaseCommand {
         }else{
             getRdOutput().info(String.format("Deleted %d executions.", result.getSuccessCount()));
         }
-        return result.isAllsuccessful();
+        return result.isAllsuccessful()?0:1;
     }
 
     public static boolean maybeFollow(

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Executions.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Executions.java
@@ -48,9 +48,6 @@ import java.util.stream.Stream;
  */
 @CommandLine.Command(name = "executions", description = "List running executions, attach and follow their output, or kill them.")
 public class Executions extends BaseCommand {
-
-    private static final ObjectMapper JSON = new ObjectMapper();
-
     @Getter
     @Setter
     static class KillOptions extends ExecutionIdOption{
@@ -532,7 +529,7 @@ public class Executions extends BaseCommand {
 
     // End Delete all executions.
 
-    static interface HasJobIdList {
+    interface HasJobIdList {
         List<String> getJobIdList();
 
         default boolean isJobIdList() {
@@ -651,7 +648,7 @@ public class Executions extends BaseCommand {
     /**
      * @param millis wait time
      *
-     * @return wait function which returns false if interrupted, true otherwise
+     * @return wait function which returns false if interrupted true otherwise
      */
     private static BooleanSupplier waitUnlessInterrupt(final int millis) {
         return () -> {

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Executions.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Executions.java
@@ -16,7 +16,6 @@
 
 package org.rundeck.client.tool.commands;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.Setter;
 import okhttp3.ResponseBody;

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Keys.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Keys.java
@@ -119,7 +119,7 @@ public class Keys extends BaseCommand {
 
     @CommandLine.Command(description = "List the keys and directories at a given path, or at the root by default.",
             aliases = {"ls"})
-    public boolean list(@CommandLine.Mixin OptionalPath opts) throws IOException, InputError {
+    public int list(@CommandLine.Mixin OptionalPath opts) throws IOException, InputError {
 
         KeyStorageItem keyStorageItem = apiCall(api -> api.listKeyStorage(opts.getPath().keysPath()));
 
@@ -131,10 +131,10 @@ public class Keys extends BaseCommand {
                             .sorted()
                             .map(KeyStorageItem::toBasicString)
                             .collect(Collectors.toList()));
-            return true;
+            return 0;
         } else {
             getRdOutput().error(String.format("Path is not a directory: %s", opts.getPath()));
-            return false;
+            return 2;
         }
     }
 
@@ -177,13 +177,13 @@ public class Keys extends BaseCommand {
     }
 
     @CommandLine.Command(description = "Get the contents of a public key")
-    public boolean get(@CommandLine.Mixin GetOpts options) throws IOException, InputError {
+    public int get(@CommandLine.Mixin GetOpts options) throws IOException, InputError {
         validateRequired(options);
         KeyStorageItem keyStorageItem = apiCall(api -> api.listKeyStorage(options.getPath().keysPath()));
 
         if (keyStorageItem.getType() != KeyStorageItem.KeyItemType.file) {
             getRdOutput().error(String.format("Requested path (%s) is not a file", options.getPath()));
-            return false;
+            return 2;
         }
         if (keyStorageItem.getFileType() != KeyStorageItem.KeyFileType.publicKey) {
             getRdOutput().error(String.format(
@@ -191,7 +191,7 @@ public class Keys extends BaseCommand {
                     options.getPath(),
                     keyStorageItem.getFileType()
             ));
-            return false;
+            return 2;
         }
         try (ResponseBody body = apiCall(api -> api.getPublicKey(options.getPath().keysPath()))) {
             if (!ServiceClient.hasAnyMediaType(body.contentType(), Client.MEDIA_TYPE_GPG_KEYS)) {
@@ -213,7 +213,7 @@ public class Keys extends BaseCommand {
                 Util.copyStream(inputStream, System.out);
             }
         }
-        return true;
+        return 0;
     }
 
 

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Metrics.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Metrics.java
@@ -79,7 +79,7 @@ public class Metrics extends BaseCommand {
   }
 
   @CommandLine.Command(description = "Print health check status information.")
-  public boolean healthcheck(@CommandLine.Mixin HealthCheckOptions options) throws IOException, InputError {
+  public int healthcheck(@CommandLine.Mixin HealthCheckOptions options) throws IOException, InputError {
 
     Map<String, HealthCheckStatus> healthCheckStatus = apiCall(RundeckApi::getHealthCheckMetrics);
 
@@ -111,7 +111,7 @@ public class Metrics extends BaseCommand {
       getRdOutput().warning("No results found.");
     }
 
-    return !options.isFailOnUnhealthy() || unhealthyList.size() == 0;
+    return (!options.isFailOnUnhealthy() || unhealthyList.size() == 0) ? 0 : 1;
   }
 
   // rd metrics threads

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Projects.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Projects.java
@@ -105,7 +105,7 @@ public class Projects extends BaseCommand {
     }
 
     @CommandLine.Command(description = "Delete a project")
-    public boolean delete(
+    public int delete(
             @CommandLine.Mixin ProjectDelete options,
             @CommandLine.Mixin ProjectListFormatOptions formatOptions,
             @CommandLine.Mixin VerboseOption verboseOption
@@ -123,12 +123,12 @@ public class Projects extends BaseCommand {
 
             if (!"y".equals(s)) {
                 getRdOutput().warning(String.format("Not deleting project %s.", project));
-                return false;
+                return 2;
             }
         }
         apiCall(api -> api.deleteProject(project));
         getRdOutput().info(String.format("Project was deleted: %s%n", project));
-        return true;
+        return 0;
     }
 
     @CommandLine.Command(description = "Create a project.")

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Retry.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Retry.java
@@ -43,7 +43,7 @@ import java.util.concurrent.Callable;
         name = "retry",
         showEndOfOptionsDelimiterInUsageHelp = true
 )
-public class Retry extends BaseCommand implements Callable<Boolean> {
+public class Retry extends BaseCommand implements Callable<Integer> {
 
 
 
@@ -52,12 +52,12 @@ public class Retry extends BaseCommand implements Callable<Boolean> {
     @CommandLine.Mixin
     FollowOptions followOptions;
 
-    public Boolean call() throws IOException, InputError {
+    public Integer call() throws IOException, InputError {
         getRdTool().requireApiVersion("retry", 24);
         String jobId = Run.getJobIdFromOpts(options, getRdOutput(), getRdTool(), () -> getRdTool().projectOrEnv(options));
         String execId = options.getEid();
         if (null == jobId) {
-            return false;
+            return 2;
         }
         Execution execution;
 
@@ -134,6 +134,6 @@ public class Retry extends BaseCommand implements Callable<Boolean> {
         String started = "started";
         getRdOutput().info(String.format("Execution %s: %s%n", started, execution.toBasicString()));
 
-        return Executions.maybeFollow(getRdTool(), followOptions, options, execution.getId(), getRdOutput());
+        return Executions.maybeFollow(getRdTool(), followOptions, options, execution.getId(), getRdOutput()) ? 0 : 1;
     }
 }

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/jobs/Files.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/jobs/Files.java
@@ -142,7 +142,7 @@ public class Files extends BaseCommand {
 
     @CommandLine.Command(description = "Upload a file as input for a job option (API v19). Returns a unique key for the uploaded" +
             " file, which can be used as the option value when running the job.")
-    public boolean load(@CommandLine.Mixin FileUploadOpts options) throws IOException, InputError {
+    public int load(@CommandLine.Mixin FileUploadOpts options) throws IOException, InputError {
         File input = options.getFile();
         if (!input.canRead() || !input.isFile()) {
             throw new InputError(String.format("File is not readable or does not exist: %s", input));
@@ -161,12 +161,12 @@ public class Files extends BaseCommand {
             getRdOutput().info("File " + fileName + " uploaded successfully for option " + options.getOption());
             getRdOutput().info("File key:");
             getRdOutput().output(fileid);
-            return true;
+            return 0;
         } else {
             getRdOutput().error(String.format("Expected one option result for option %s, but saw: ", options.getOption()));
         }
         getRdOutput().output(jobFileUploadResult);
-        return false;
+        return 1;
     }
 
     /**

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/projects/Archives.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/projects/Archives.java
@@ -114,7 +114,7 @@ public class Archives extends BaseCommand  {
     }
 
     @CommandLine.Command(description = "Import a project archive", name = "import")
-    public boolean importArchive(@CommandLine.Mixin ArchiveImportOpts opts) throws InputError, IOException {
+    public int importArchive(@CommandLine.Mixin ArchiveImportOpts opts) throws InputError, IOException {
         File input = opts.getFile();
         if (!input.canRead() || !input.isFile()) {
             throw new InputError(String.format("File is not readable or does not exist: %s", input));
@@ -173,7 +173,7 @@ public class Archives extends BaseCommand  {
             getRdOutput().error(status.aclErrors);
         }
 
-        return opts.isStrict() ? !anyerror : status.getResultSuccess();
+        return (opts.isStrict() ? !anyerror : status.getResultSuccess()) ? 0 : 1;
     }
 
 
@@ -215,7 +215,7 @@ public class Archives extends BaseCommand  {
     }
 
     @CommandLine.Command(description = "Export a project archive")
-    public boolean export(@CommandLine.Mixin ArchiveExportOpts opts) throws IOException, InputError {
+    public int export(@CommandLine.Mixin ArchiveExportOpts opts) throws IOException, InputError {
         if (opts.isIncludeFlags() && opts.isExecutionIds()) {
             throw new InputError("Cannot use --execids/-e with --include/-i");
         }
@@ -246,7 +246,7 @@ public class Archives extends BaseCommand  {
                     apiCall(api -> api.exportProject(project, opts.getExecutionIds())),
                     opts.getFile()
             );
-            return true;
+            return 0;
         }
         getRdOutput().info(String.format("Export Archive for project: %s", project));
         if (opts.isExecutionIds()) {
@@ -282,7 +282,7 @@ public class Archives extends BaseCommand  {
             } catch (InterruptedException e) {
                 return false;
             }
-        });
+        }) ? 0 : 2;
     }
 
     public static boolean loopStatus(

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/projects/SCM.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/projects/SCM.java
@@ -181,7 +181,7 @@ public class SCM extends BaseCommand {
 
 
     @CommandLine.Command(description = "Get SCM Status for a Project")
-    public boolean status(@CommandLine.Mixin BaseOpts opts) throws IOException, InputError {
+    public int status(@CommandLine.Mixin BaseOpts opts) throws IOException, InputError {
         String project = validate(opts);
         ScmProjectStatusResult result = apiCall(api -> api.getScmProjectStatus(
                 project,
@@ -190,7 +190,7 @@ public class SCM extends BaseCommand {
 
 
         getRdOutput().output(result.toMap());
-        return result.synchState == ScmSynchState.CLEAN;
+        return (result.synchState == ScmSynchState.CLEAN) ? 0 : 1;
     }
 
 
@@ -326,7 +326,7 @@ public class SCM extends BaseCommand {
     }
 
     @CommandLine.Command(description = "Perform SCM action")
-    public boolean perform(
+    public int perform(
             @CommandLine.Mixin BaseOpts opts,
             @CommandLine.Mixin ActionPerformOptions options
     ) throws IOException, InputError {
@@ -398,12 +398,12 @@ public class SCM extends BaseCommand {
                 "Action " + options.getAction(),
                 getRdTool().getAppConfig().isAnsiEnabled()
         )) {
-            return false;
+            return 2;
         }
 
         //otherwise check other error codes and fail if necessary
         ScmActionResult result = getRdTool().getClient().checkError(response);
-        return outputScmActionResult(getRdOutput(), result, "Action " + options.getAction());
+        return outputScmActionResult(getRdOutput(), result, "Action " + options.getAction()) ? 0 : 1;
     }
 
     private ScmActionPerform performFromOptions(final ActionPerformOptions options) throws InputError {

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/system/Mode.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/system/Mode.java
@@ -63,14 +63,14 @@ public class Mode extends BaseCommand {
 
 
     @CommandLine.Command(description = "Set execution mode Active")
-    public boolean active(@CommandLine.Mixin QuietOption opts) throws IOException, InputError {
-        return changeMode(opts, ExecutionMode.active, RundeckApi::executionModeEnable);
+    public int active(@CommandLine.Mixin QuietOption opts) throws IOException, InputError {
+        return changeMode(opts, ExecutionMode.active, RundeckApi::executionModeEnable) ? 0 : 1;
     }
 
 
     @CommandLine.Command(description = "Set execution mode Passive")
-    public boolean passive(@CommandLine.Mixin QuietOption opts) throws IOException, InputError {
-        return changeMode(opts, ExecutionMode.passive, RundeckApi::executionModeDisable);
+    public int passive(@CommandLine.Mixin QuietOption opts) throws IOException, InputError {
+        return changeMode(opts, ExecutionMode.passive, RundeckApi::executionModeDisable) ? 0 : 1;
     }
 
     boolean changeMode(

--- a/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/AdhocSpec.groovy
+++ b/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/AdhocSpec.groovy
@@ -53,7 +53,7 @@ class AdhocSpec extends Specification {
             it.url = (url ? scriptUrl : null)
         }
         when: "we run adhoc script file"
-        adhoc.call()
+        def result = adhoc.call()
         then: "api call has correct values"
         1 * api."${url ? 'runUrl' : 'runScript'}"(
                 'aproject',
@@ -68,6 +68,7 @@ class AdhocSpec extends Specification {
             ) >> Calls.response(new AdhocResponse(message: 'ok', execution: new Execution(id: '123')))
             1 * api.getExecution('123') >> Calls.response(new Execution(id: '123', description: 'asdf'))
             0 * api._(*_)
+            result == 0
 
         cleanup:
             tempFile.delete()

--- a/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/ExecutionsSpec.groovy
+++ b/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/ExecutionsSpec.groovy
@@ -199,7 +199,7 @@ class ExecutionsSpec extends Specification {
 
     def "parse execution"() {
         given:
-        MockWebServer server = new MockWebServer();
+        MockWebServer server = new MockWebServer()
         server.enqueue(new MockResponse().setBody('''{
   "id": 5418,
   "href": "http://ecto1.local:4440/api/19/execution/5418",
@@ -233,7 +233,7 @@ class ExecutionsSpec extends Specification {
   ]
 }'''
         ).addHeader('content-type', 'application/json')
-        );
+        )
         server.start()
 
         def retrofit = new Retrofit.Builder().baseUrl(server.url('/api/19/')).
@@ -256,7 +256,7 @@ class ExecutionsSpec extends Specification {
 
     def "parse compacted log"() {
         given:
-        MockWebServer server = new MockWebServer();
+        MockWebServer server = new MockWebServer()
         server.enqueue(new MockResponse().setBody('''{
   "id": 5418,
   "compacted":true,
@@ -269,7 +269,7 @@ class ExecutionsSpec extends Specification {
   "serverUUID": "3425B691-7319-4EEE-8425-F053C628B4BA"
 }'''
         ).addHeader('content-type', 'application/json')
-        );
+        )
         server.start()
 
         def retrofit = new Retrofit.Builder().baseUrl(server.url('/api/19/')).

--- a/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/ExecutionsSpec.groovy
+++ b/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/ExecutionsSpec.groovy
@@ -71,8 +71,8 @@ class ExecutionsSpec extends Specification {
 
         where:
         reqd  | expect
-        true  | false
-        false | true
+        true  | 2
+        false | 0
     }
 
     private RdTool setupMock(RundeckApi api) {

--- a/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/JobsSpec.groovy
+++ b/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/JobsSpec.groovy
@@ -16,6 +16,9 @@
 
 package org.rundeck.client.tool.commands
 
+import org.rundeck.client.api.model.BulkToggleJobExecutionResponse
+import org.rundeck.client.api.model.BulkToggleJobScheduleResponse
+import org.rundeck.client.api.model.DeleteJob
 import org.rundeck.client.api.model.Simple
 import org.rundeck.client.api.model.scheduler.ForecastJobItem
 import org.rundeck.client.testing.MockRdTool
@@ -33,6 +36,7 @@ import org.rundeck.client.api.model.JobLoadItem
 import org.rundeck.client.api.model.scheduler.ScheduledJobItem
 import org.rundeck.client.tool.RdApp
 import org.rundeck.client.tool.extension.RdTool
+import org.rundeck.client.tool.options.BulkJobActionOptions
 import org.rundeck.client.tool.options.JobFileOptions
 import org.rundeck.client.tool.options.JobIdentOptions
 import org.rundeck.client.tool.options.JobListOptions
@@ -209,7 +213,7 @@ class JobsSpec extends Specification {
                 Calls.response([new JobItem(id: 'fakeid')])
         1 * api.deleteJobsBulk({ it.ids == ['fakeid'] }) >> Calls.response(new DeleteJobsResult(allsuccessful: true))
         0 * api._(*_)
-        result
+        result == 0
 
         where:
         job  | group | jobexact | groupexact
@@ -219,6 +223,38 @@ class JobsSpec extends Specification {
         null | null  | 'a'      | null
         null | null  | 'a'      | 'b/c'
         null | null  | null     | 'b/c'
+    }
+    @Unroll
+    def "job purge some failure"() {
+        given:
+        def api = Mock(RundeckApi)
+        RdTool rdTool = setupMock(api)
+        def out = Mock(CommandOutput)
+        Jobs command = new Jobs()
+        command.rdTool = rdTool
+        command.rdOutput = out
+
+        def opts = new Jobs.Purge()
+        opts.confirm = true
+        def listOpts = new JobListOptions()
+        listOpts.setJob(job)
+        listOpts.setProject 'ProjectName'
+
+        when:
+        def result = command.purge(opts, new JobOutputFormatOption(), new JobFileOptions(), listOpts)
+
+        then:
+        1 * api.listJobs('ProjectName', job, null,null,null) >>
+                Calls.response([new JobItem(id: 'fakeid')])
+        1 * api.deleteJobsBulk({ it.ids == ['fakeid'] }) >> Calls.response(new DeleteJobsResult(allsuccessful: allsuccess, failed: allsuccess?[]:[new DeleteJob(id:'fakeid')]))
+        0 * api._(*_)
+        result == exit
+
+        where:
+        job='a'
+        allsuccess | exit
+        true | 0
+        false | 1
     }
     @Unroll
     def "job purge with with batchsize"() {
@@ -252,7 +288,7 @@ class JobsSpec extends Specification {
             Calls.response(new DeleteJobsResult(allsuccessful: true))
         }
         0 * api._(*_)
-        result
+        result == 0
 
         where:
             job | batch | total | max || expect
@@ -345,7 +381,7 @@ class JobsSpec extends Specification {
         command.rdOutput=out
 
         when:
-        command.load(new JobLoadOptions(), opts,new ProjectNameOptions(project:'ProjectName'),new VerboseOption())
+        def result = command.load(new JobLoadOptions(), opts,new ProjectNameOptions(project:'ProjectName'),new VerboseOption())
 
         then:
         1 * api.loadJobs('ProjectName', _, 'yaml', _, _) >>
@@ -358,6 +394,34 @@ class JobsSpec extends Specification {
         1 * out.info('1 Jobs Failed:\n')
         1 * out.output(['[id:?] Job Name\n\t:Test Error'])
         0 * out._(*_)
+        result == 1
+
+    }
+    def "job load success"() {
+        given:
+        def opts = new JobFileOptions()
+        opts.format= JobFileOptions.Format.yaml
+        opts.file=tempFile
+
+
+        def api = Mock(RundeckApi)
+        RdTool rdTool = setupMock(api)
+        def out = Mock(CommandOutput)
+        Jobs command = new Jobs()
+        command.rdTool=rdTool
+        command.rdOutput=out
+
+        when:
+        def result = command.load(new JobLoadOptions(), opts,new ProjectNameOptions(project:'ProjectName'),new VerboseOption())
+
+        then:
+        1 * api.loadJobs('ProjectName', _, 'yaml', _, _) >>
+                Calls.response(new ImportResult(succeeded: [new JobLoadItem( id:'jobid',name: 'Job Name')], skipped: [], failed: []))
+        0 * api._(*_)
+        1 * out.info('1 Jobs Succeeded:\n')
+        1 * out.output(['jobid Job Name'])
+        0 * out._(*_)
+        result == 0
 
     }
 
@@ -375,7 +439,7 @@ class JobsSpec extends Specification {
 
             def resultItem = new JobLoadItem(error: 'Test Error', name: 'Job Name')
         when:
-            command.load(new JobLoadOptions(), opts,new ProjectNameOptions(project:'ProjectName'),new VerboseOption(verbose: true))
+            def result = command.load(new JobLoadOptions(), opts,new ProjectNameOptions(project:'ProjectName'),new VerboseOption(verbose: true))
 
         then:
             1 * api.loadJobs('ProjectName', _, 'yaml', _, _) >>
@@ -384,6 +448,7 @@ class JobsSpec extends Specification {
             1 * out.info('1 Jobs Failed:\n')
             1 * out.output([resultItem])
             0 * out._(*_)
+            result == 1
 
     }
 
@@ -408,6 +473,222 @@ class JobsSpec extends Specification {
         1 * out.output('Forecast:')
         1 * out.output([date])
 
+    }
+    def "exec enable"() {
+        given:
+        def api = Mock(RundeckApi)
+        RdTool rdTool = setupMock(api, 31)
+        def out = Mock(CommandOutput)
+        Jobs command = new Jobs()
+        command.rdTool = rdTool
+        command.rdOutput = out
+        def opts = new JobIdentOptions()
+        opts.id = 'jobid'
+
+
+        def date = new Date()
+
+        when:
+        def result = command.enable(opts)
+
+        then:
+        1 * api.jobExecutionEnable('jobid') >> Calls.response(new Simple(success: issuccess))
+        0 * api._(*_)
+        result == exit
+        where:
+        issuccess | exit
+        true      | 0
+        false     | 1
+    }
+    def "exec disable"() {
+        given:
+        def api = Mock(RundeckApi)
+        RdTool rdTool = setupMock(api, 31)
+        def out = Mock(CommandOutput)
+        Jobs command = new Jobs()
+        command.rdTool = rdTool
+        command.rdOutput = out
+        def opts = new JobIdentOptions()
+        opts.id = 'jobid'
+
+
+        def date = new Date()
+
+        when:
+        def result = command.disable(opts)
+
+        then:
+        1 * api.jobExecutionDisable('jobid') >> Calls.response(new Simple(success: issuccess))
+        0 * api._(*_)
+        result == exit
+        where:
+        issuccess | exit
+        true      | 0
+        false     | 1
+    }
+    def "schedule enable"() {
+        given:
+        def api = Mock(RundeckApi)
+        RdTool rdTool = setupMock(api, 31)
+        def out = Mock(CommandOutput)
+        Jobs command = new Jobs()
+        command.rdTool = rdTool
+        command.rdOutput = out
+        def opts = new JobIdentOptions()
+        opts.id = 'jobid'
+
+
+        def date = new Date()
+
+        when:
+        def result = command.reschedule(opts)
+
+        then:
+        1 * api.jobScheduleEnable('jobid') >> Calls.response(new Simple(success: issuccess))
+        0 * api._(*_)
+        result == exit
+        where:
+        issuccess | exit
+        true      | 0
+        false     | 1
+    }
+    def "schedule disable"() {
+        given:
+        def api = Mock(RundeckApi)
+        RdTool rdTool = setupMock(api, 31)
+        def out = Mock(CommandOutput)
+        Jobs command = new Jobs()
+        command.rdTool = rdTool
+        command.rdOutput = out
+        def opts = new JobIdentOptions()
+        opts.id = 'jobid'
+
+
+        def date = new Date()
+
+        when:
+        def result = command.unschedule(opts)
+
+        then:
+        1 * api.jobScheduleDisable('jobid') >> Calls.response(new Simple(success: issuccess))
+        0 * api._(*_)
+        result == exit
+        where:
+        issuccess | exit
+        true      | 0
+        false     | 1
+    }
+    def "exec enable bulk"() {
+        given:
+        def api = Mock(RundeckApi)
+        RdTool rdTool = setupMock(api, 31)
+        def out = Mock(CommandOutput)
+        Jobs command = new Jobs()
+        command.rdTool = rdTool
+        command.rdOutput = out
+        def opts = new BulkJobActionOptions()
+        opts.confirm = true
+        opts.idlist = ['jobid']
+
+
+        when:
+        def result = command.enablebulk(opts, new VerboseOption())
+
+        then:
+        1 * api.bulkEnableJobs(_) >> Calls.response(new BulkToggleJobExecutionResponse(
+                allsuccessful: issuccess,
+                failed: issuccess?[]:[new BulkToggleJobExecutionResponse.Result()]
+        ))
+        0 * api._(*_)
+        result == exit
+        where:
+        issuccess | exit
+        true      | 0
+        false     | 1
+    }
+    def "exec disable bulk"() {
+        given:
+        def api = Mock(RundeckApi)
+        RdTool rdTool = setupMock(api, 31)
+        def out = Mock(CommandOutput)
+        Jobs command = new Jobs()
+        command.rdTool = rdTool
+        command.rdOutput = out
+        def opts = new BulkJobActionOptions()
+        opts.confirm = true
+        opts.idlist = ['jobid']
+
+
+        when:
+        def result = command.disablebulk(opts, new VerboseOption())
+
+        then:
+        1 * api.bulkDisableJobs(_) >> Calls.response(new BulkToggleJobExecutionResponse(
+                allsuccessful: issuccess,
+                failed: issuccess?[]:[new BulkToggleJobExecutionResponse.Result()]
+        ))
+        0 * api._(*_)
+        result == exit
+        where:
+        issuccess | exit
+        true      | 0
+        false     | 1
+    }
+    def "schedule enable bulk"() {
+        given:
+        def api = Mock(RundeckApi)
+        RdTool rdTool = setupMock(api, 31)
+        def out = Mock(CommandOutput)
+        Jobs command = new Jobs()
+        command.rdTool = rdTool
+        command.rdOutput = out
+        def opts = new BulkJobActionOptions()
+        opts.confirm = true
+        opts.idlist = ['jobid']
+
+
+        when:
+        def result = command.reschedulebulk(opts, new VerboseOption())
+
+        then:
+        1 * api.bulkEnableJobSchedule(_) >> Calls.response(new BulkToggleJobScheduleResponse(
+                allsuccessful: issuccess,
+                failed: issuccess?[]:[new BulkToggleJobScheduleResponse.Result()]
+        ))
+        0 * api._(*_)
+        result == exit
+        where:
+        issuccess | exit
+        true      | 0
+        false     | 1
+    }
+    def "schedule disable bulk"() {
+        given:
+        def api = Mock(RundeckApi)
+        RdTool rdTool = setupMock(api, 31)
+        def out = Mock(CommandOutput)
+        Jobs command = new Jobs()
+        command.rdTool = rdTool
+        command.rdOutput = out
+        def opts = new BulkJobActionOptions()
+        opts.confirm = true
+        opts.idlist = ['jobid']
+
+
+        when:
+        def result = command.unschedulebulk(opts, new VerboseOption())
+
+        then:
+        1 * api.bulkDisableJobSchedule(_) >> Calls.response(new BulkToggleJobScheduleResponse(
+                allsuccessful: issuccess,
+                failed: issuccess?[]:[new BulkToggleJobScheduleResponse.Result()]
+        ))
+        0 * api._(*_)
+        result == exit
+        where:
+        issuccess | exit
+        true      | 0
+        false     | 1
     }
 
 

--- a/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/ProjectsSpec.groovy
+++ b/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/ProjectsSpec.groovy
@@ -107,4 +107,27 @@ class ProjectsSpec extends Specification {
         '%name/%config'      | ['abc/{xyz=993}', 'def/']
         '%name/%config.xyz'  | ['abc/993', 'def/']
     }
+    def "projects delete"() {
+        given:
+        def api = Mock(RundeckApi)
+        RdTool rdTool = setupMock(api)
+        def out = Mock(CommandOutput)
+        Projects command = new Projects()
+        command.rdTool = rdTool
+        command.rdOutput = out
+
+        def verbose = new VerboseOption()
+        def format = new ProjectListFormatOptions()
+        def opts = new Projects.ProjectDelete()
+        opts.project='aproject'
+        opts.confirm = true
+
+        when:
+        def result=command.delete(opts,format, verbose)
+
+        then:
+        1 * api.deleteProject('aproject')>>Calls.response(null)
+        0 * api._(*_)
+        result == 0
+    }
 }

--- a/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/RetrySpec.groovy
+++ b/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/RetrySpec.groovy
@@ -90,7 +90,7 @@ class RetrySpec extends Specification {
         }
         ) >> Calls.response(new Execution(id: 123, description: ''))
         0 * api._(*_)
-        result
+        result==0
     }
     def "error on api version below 24"() {
         given:

--- a/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/jobs/FilesSpec.groovy
+++ b/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/jobs/FilesSpec.groovy
@@ -1,0 +1,77 @@
+package org.rundeck.client.tool.commands.jobs
+
+import groovy.transform.CompileStatic
+import org.rundeck.client.api.RundeckApi
+import org.rundeck.client.api.model.ExecutionList
+import org.rundeck.client.api.model.JobFileUploadResult
+import org.rundeck.client.api.model.Paging
+import org.rundeck.client.testing.MockRdTool
+import org.rundeck.client.tool.CommandOutput
+import org.rundeck.client.tool.RdApp
+import org.rundeck.client.tool.commands.Executions
+import org.rundeck.client.tool.extension.RdTool
+import org.rundeck.client.tool.options.ExecutionOutputFormatOption
+import org.rundeck.client.tool.options.PagingResultOptions
+import org.rundeck.client.util.Client
+import org.rundeck.client.util.RdClientConfig
+import retrofit2.Retrofit
+import retrofit2.mock.Calls
+import spock.lang.Specification
+
+class FilesSpec extends Specification {
+
+
+    def "load"() {
+
+        given:
+
+        File toupload = java.nio.file.Files.createTempFile('test', 'file').toFile()
+        toupload << 'content'
+        toupload.deleteOnExit()
+        String fileName = toupload.getName()
+        def api = Mock(RundeckApi)
+        RdTool rdTool = setupMock(api)
+        def out = Mock(CommandOutput)
+        Files command = new Files()
+        command.rdTool = rdTool
+        command.rdOutput = out
+
+        def options = new Files.FileUploadOpts()
+        options.with {
+            it.id = 'jobId'
+            it.option = 'optionName'
+            it.file = toupload
+        }
+
+        when:
+        def result = command.load(options)
+        then:
+        1 * api.uploadJobOptionFile('jobId', 'optionName', fileName, _) >> Calls.response(
+                new JobFileUploadResult(total: 1, options: resultopts)
+        )
+        result == expect
+
+        cleanup:
+
+        toupload.delete()
+
+        where:
+        resultopts              | expect
+        [:]                     | 1
+        [optionName: 'afileid'] | 0
+
+    }
+
+    private RdTool setupMock(RundeckApi api) {
+        def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
+        def client = new Client(api, retrofit, null, null, 18, true, null)
+        def rdapp = Mock(RdApp) {
+            getClient() >> client
+            getAppConfig() >> Mock(RdClientConfig)
+        }
+        def rdTool = new MockRdTool(client: client, rdApp: rdapp)
+        rdTool.appConfig = Mock(RdClientConfig)
+        rdTool
+    }
+
+}

--- a/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/system/ModeSpec.groovy
+++ b/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/system/ModeSpec.groovy
@@ -1,0 +1,79 @@
+package org.rundeck.client.tool.commands.system
+
+import groovy.transform.CompileStatic
+import org.rundeck.client.api.RundeckApi
+import org.rundeck.client.api.model.ExecutionMode
+import org.rundeck.client.api.model.SystemMode
+import org.rundeck.client.testing.MockRdTool
+import org.rundeck.client.tool.CommandOutput
+import org.rundeck.client.tool.RdApp
+import org.rundeck.client.tool.commands.enterprise.api.EnterpriseApi
+import org.rundeck.client.tool.commands.enterprise.api.model.EnterpriseModeResponse
+import org.rundeck.client.tool.extension.RdTool
+import org.rundeck.client.tool.options.QuietOption
+import org.rundeck.client.util.Client
+import org.rundeck.client.util.RdClientConfig
+import retrofit2.Retrofit
+import retrofit2.mock.Calls
+import spock.lang.Specification
+
+class ModeSpec extends Specification {
+    private RdTool setupMock(RundeckApi api, CommandOutput out, int apiVersion) {
+        def retrofit = new Retrofit.Builder().baseUrl('http://example.com/fake/').build()
+        def client = new Client(api, retrofit, null, null, apiVersion, true, null)
+        def rdapp = Mock(RdApp) {
+            getClient() >> client
+            getAppConfig() >> Mock(RdClientConfig)
+            getOutput() >> out
+        }
+        def rdTool = new MockRdTool(client: client, rdApp: rdapp)
+        rdTool.appConfig = Mock(RdClientConfig)
+        rdTool
+    }
+
+    def "passive"() {
+        def api = Mock(RundeckApi)
+        def out = Mock(CommandOutput)
+        RdTool rdTool = setupMock(api, out, 41)
+        Mode command = new Mode()
+        command.rdOutput = out
+        command.rdTool = rdTool
+        def opts = new QuietOption()
+
+
+        when:
+        def result = command.passive(opts)
+
+        then:
+        1 * api.executionModeDisable() >> Calls.response(new SystemMode(executionMode: respstatus as ExecutionMode))
+        0 * api._(*_)
+        result == expected
+        where:
+        respstatus | expected
+        'active'   | 1
+        'passive'  | 0
+    }
+
+    def "active"() {
+        def api = Mock(RundeckApi)
+        def out = Mock(CommandOutput)
+        RdTool rdTool = setupMock(api, out, 41)
+        Mode command = new Mode()
+        command.rdOutput = out
+        command.rdTool = rdTool
+        def opts = new QuietOption()
+
+
+        when:
+        def result = command.active(opts)
+
+        then:
+        1 * api.executionModeEnable() >> Calls.response(new SystemMode(executionMode: respstatus as ExecutionMode))
+        0 * api._(*_)
+        result == expected
+        where:
+        respstatus | expected
+        'active'   | 0
+        'passive'  | 1
+    }
+}


### PR DESCRIPTION
extends pr #385 

conversion to picocli broke the exit code behavior for a number of commands on failure:

* acl test/validate
* adhoc -f
* projects archives import --strict
* projects archives export (asynch wait failure)
* executions kill (failure)
* executions follow
* jobs files load
* jobs purge/load/enable/disable/reschedule/unschedule/enablebulk/disablebulk/reschedulebulk/unschedulebulk
* keys list/get
* license status
* metrics healthcheck
* cluster mode active/passive
* system mode active/passive
* projects delete
* retry
* scm status/perform
