### PR TITLE
RSE-329: jdk11-warning

### DIFF
--- a/rd-cli-tool/build.gradle
+++ b/rd-cli-tool/build.gradle
@@ -105,13 +105,8 @@ set -e
 RD_CONF=${RD_CONF:-$HOME/.$APP_NAME/$APP_NAME.conf}
 test -f $RD_CONF && . $RD_CONF
 export RD_EXT_DIR=${RD_EXT_DIR:-$HOME/.$APP_NAME/extv2}
-'''
-    )
-    def setJ11AddOpens=appendConfigData.curry(
-        '^APP_ARGS=.*$',
-        '''
-if $JAVACMD --add-opens 2>&1 | grep 'requires modules' >/dev/null; then
-  JAVA_OPTS="$JAVA_OPTS --add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+if [ ! -z "$(java --add-opens 2>&1 | grep 'requires modules')" ]; then
+  export JAVA_OPTS="$JAVA_OPTS --add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
 fi
 '''
     )
@@ -126,7 +121,6 @@ fi
                         .readLines()
                         .collect(setE)
                         .collect(setClasspath)
-                        .collect(setJ11AddOpens)
                         .join('\n')
     }
 


### PR DESCRIPTION
Removes warning message when running on java11. Previous fix was not running and "JAVACMD" variable was out of the scope.