### PR TITLE
remove use of XML in api responses. remove --xml option for execution metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+* Remove use of XML in API calls (deprecated in Rundeck 4.x)
+* Remove `--xml` option for executions metrics
+
 ## 2.0.6
 
 * dependency updates

--- a/rd-api-client/src/main/java/org/rundeck/client/api/RundeckApi.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/api/RundeckApi.java
@@ -203,13 +203,11 @@ public interface RundeckApi {
             @Query("format") String format
     );
 
-    @Xml
-    @Headers("Accept: application/xml")
+    @Headers("Accept: application/json")
     @POST("project/{project}/jobs/import")
     Call<ImportResult> loadJobs(@Path("project") String project, @Body RequestBody body);
 
-    @Xml
-    @Headers("Accept: application/xml")
+    @Headers("Accept: application/json")
     @POST("project/{project}/jobs/import")
     Call<ImportResult> loadJobs(
             @Path("project") String project,
@@ -1262,44 +1260,6 @@ public interface RundeckApi {
     @Headers("Accept: application/json")
     @GET("executions/metrics")
     Call<MetricsResponse> executionMetrics(
-        @QueryMap Map<String, String> options,
-        @Query("jobIdListFilter") List<String> jobIdListFilter,
-        @Query("excludeJobIdListFilter") List<String> xjobIdListFilter,
-        @Query("jobListFilter") List<String> jobListFilter,
-        @Query("excludeJobListFilter") List<String> excludeJobListFilters
-    );
-
-    /**
-     * Get stats on a project-wide query of executions, with all query parameters available, in XML format.
-     * @param project
-     * @param options
-     * @param jobIdListFilter
-     * @param xjobIdListFilter
-     * @param jobListFilter
-     * @param excludeJobListFilters
-     */
-    @Headers("Accept: application/xml")
-    @GET("project/{project}/executions/metrics")
-    Call<ResponseBody> executionMetricsXML(
-        @Path("project") String project,
-        @QueryMap Map<String, String> options,
-        @Query("jobIdListFilter") List<String> jobIdListFilter,
-        @Query("excludeJobIdListFilter") List<String> xjobIdListFilter,
-        @Query("jobListFilter") List<String> jobListFilter,
-        @Query("excludeJobListFilter") List<String> excludeJobListFilters
-    );
-
-   /**
-     * Get stats on a system-wide query of executions, with all query parameters available, in XML format.
-     * @param options
-     * @param jobIdListFilter
-     * @param xjobIdListFilter
-     * @param jobListFilter
-     * @param excludeJobListFilters
-     */
-    @Headers("Accept: application/xml")
-    @GET("executions/metrics")
-    Call<ResponseBody> executionMetricsXML(
         @QueryMap Map<String, String> options,
         @Query("jobIdListFilter") List<String> jobIdListFilter,
         @Query("excludeJobIdListFilter") List<String> xjobIdListFilter,

--- a/rd-api-client/src/main/java/org/rundeck/client/api/RundeckApi.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/api/RundeckApi.java
@@ -31,7 +31,6 @@ import org.rundeck.client.api.model.scheduler.ScheduledJobItem;
 import org.rundeck.client.api.model.scheduler.SchedulerTakeover;
 import org.rundeck.client.api.model.scheduler.SchedulerTakeoverResult;
 import org.rundeck.client.util.Json;
-import org.rundeck.client.util.Xml;
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/rd-api-client/src/main/java/org/rundeck/client/api/model/ImportResult.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/api/model/ImportResult.java
@@ -17,46 +17,16 @@
 package org.rundeck.client.api.model;
 
 
+import lombok.Data;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
-@XmlRootElement()
+@Data
 public class ImportResult {
     private List<JobLoadItem> succeeded;
     private List<JobLoadItem> failed;
     private List<JobLoadItem> skipped;
-
-    @XmlElementWrapper
-    @XmlElement(name = "job")
-    public List<JobLoadItem> getSucceeded() {
-        return succeeded;
-    }
-
-    public void setSucceeded(List<JobLoadItem> succeeded) {
-        this.succeeded = succeeded;
-    }
-
-    @XmlElementWrapper
-    @XmlElement(name = "job")
-    public List<JobLoadItem> getFailed() {
-        return failed;
-    }
-
-    public void setFailed(List<JobLoadItem> failed) {
-        this.failed = failed;
-    }
-
-    @XmlElementWrapper
-    @XmlElement(name = "job")
-    public List<JobLoadItem> getSkipped() {
-        return skipped;
-    }
-
-    public void setSkipped(List<JobLoadItem> skipped) {
-        this.skipped = skipped;
-    }
-
-
 }

--- a/rd-api-client/src/main/java/org/rundeck/client/api/model/JobFileItem.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/api/model/JobFileItem.java
@@ -17,9 +17,9 @@
 package org.rundeck.client.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
 import org.rundeck.client.util.DataOutput;
 
-import javax.xml.bind.annotation.XmlRootElement;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,8 +27,8 @@ import java.util.Map;
  * @author greg
  * @since 3/1/17
  */
+@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
-@XmlRootElement()
 public class JobFileItem implements DataOutput {
     private String id;
     private String user;
@@ -43,108 +43,12 @@ public class JobFileItem implements DataOutput {
     private String expirationDate;
     private Long execId;
 
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getUser() {
-        return user;
-    }
-
-    public void setUser(String user) {
-        this.user = user;
-    }
-
-    public String getOptionName() {
-        return optionName;
-    }
-
-    public void setOptionName(String optionName) {
-        this.optionName = optionName;
-    }
-
-    public String getFileState() {
-        return fileState;
-    }
-
-    public void setFileState(String fileState) {
-        this.fileState = fileState;
-    }
-
-    public String getSha() {
-        return sha;
-    }
-
-    public void setSha(String sha) {
-        this.sha = sha;
-    }
-
-    public String getJobId() {
-        return jobId;
-    }
-
-    public void setJobId(String jobId) {
-        this.jobId = jobId;
-    }
-
-    public String getDateCreated() {
-        return dateCreated;
-    }
-
     public DateInfo dateInfoDateCreated() {
         return new DateInfo(dateCreated);
     }
 
-    public void setDateCreated(String dateCreated) {
-        this.dateCreated = dateCreated;
-    }
-
-    public String getServerNodeUUID() {
-        return serverNodeUUID;
-    }
-
-    public void setServerNodeUUID(String serverNodeUUID) {
-        this.serverNodeUUID = serverNodeUUID;
-    }
-
-    public String getFileName() {
-        return fileName;
-    }
-
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
-    }
-
-    public Long getSize() {
-        return size;
-    }
-
-    public void setSize(Long size) {
-        this.size = size;
-    }
-
-    public String getExpirationDate() {
-        return expirationDate;
-    }
-
     public DateInfo dateInfoExpirationDate() {
         return new DateInfo(expirationDate);
-    }
-
-    public void setExpirationDate(String expirationDate) {
-        this.expirationDate = expirationDate;
-    }
-
-    public Long getExecId() {
-        return execId;
-    }
-
-    public void setExecId(Long execId) {
-        this.execId = execId;
     }
 
     public Map<?, ?> asMap() {

--- a/rd-api-client/src/main/java/org/rundeck/client/api/model/JobItem.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/api/model/JobItem.java
@@ -17,17 +17,15 @@
 package org.rundeck.client.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
 import org.rundeck.client.util.DataOutput;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
-@XmlRootElement()
 public class JobItem implements DataOutput {
     private String id;
     private String name;
@@ -36,70 +34,7 @@ public class JobItem implements DataOutput {
     private String description;
     private String href;
     private String permalink;
-
     private Long averageDuration;
-
-    @XmlElement()
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    @XmlElement()
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @XmlElement()
-    public String getGroup() {
-        return group;
-    }
-
-    public void setGroup(String group) {
-        this.group = group;
-    }
-
-    @XmlElement
-    public String getProject() {
-        return project;
-    }
-
-    public void setProject(String project) {
-        this.project = project;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    @XmlAttribute()
-    public String getHref() {
-        return href;
-    }
-
-    public void setHref(String href) {
-        this.href = href;
-    }
-
-    @XmlElement()
-    public String getPermalink() {
-        return permalink;
-    }
-
-    public void setPermalink(String permalink) {
-        this.permalink = permalink;
-    }
 
     @Override
     public String toString() {
@@ -138,14 +73,5 @@ public class JobItem implements DataOutput {
 
     public String toBasicString() {
         return String.format("%s %s%s", id, group != null ? group + "/" : "", name != null ? name : "");
-    }
-
-    @XmlAttribute()
-    public Long getAverageDuration() {
-        return averageDuration;
-    }
-
-    public void setAverageDuration(Long averageDuration) {
-        this.averageDuration = averageDuration;
     }
 }

--- a/rd-api-client/src/main/java/org/rundeck/client/api/model/JobLoadItem.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/api/model/JobLoadItem.java
@@ -17,26 +17,17 @@
 package org.rundeck.client.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 import java.util.HashMap;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@XmlRootElement()
 public class JobLoadItem extends JobItem {
 
-    private String error;
-
-    @XmlElement()
-    public String getError() {
-        return error;
-    }
-
-    public void setError(String error) {
-        this.error = error;
-    }
+    @Getter @Setter private String error;
+    @Getter @Setter private Integer index;
 
     @Override
     public String toBasicString() {

--- a/rd-api-client/src/test/groovy/org/rundeck/client/api/model/ImportResultSpec.groovy
+++ b/rd-api-client/src/test/groovy/org/rundeck/client/api/model/ImportResultSpec.groovy
@@ -4,55 +4,59 @@ import okhttp3.MediaType
 import okhttp3.ResponseBody
 import retrofit2.Converter
 import retrofit2.Retrofit
+import retrofit2.converter.jackson.JacksonConverterFactory
 import retrofit2.converter.jaxb.JaxbConverterFactory
 import spock.lang.Specification
 
 import java.lang.annotation.Annotation
 
 class ImportResultSpec extends Specification {
-    def "parse import result xml"(){
+    def "parse import result json"() {
         given:
-            def xmlText='''<result success='true' apiversion='35'>
-  <succeeded count='0' />
-  <failed count='2'>
-    <job index='1'>
-      <name>test00</name>
-      <group>group00</group>
-      <project>bongo</project>
-      <error>Cannot create a Job with UUID 17b07de4-f47d-4ab1-9f3a-8d47b33058c4: a Job already exists...</error>
-    </job>
-    <job index='2'>
-      <name>test01</name>
-      <group></group>
-      <project>bongo</project>
-      <error>...errr</error>
-    </job>
-  </failed>
-  <skipped count='2'>
-    <job index='12'>
-      <name>test02</name>
-      <group>group02</group>
-      <project>bongo</project>
-      
-      <error>...errr</error>
-    </job>
-    <job index='13'>
-      <name>test03</name>
-      <group></group>
-      <project>bongo</project>
-      <error>...errr</error>
-    </job>
-  </skipped> 
-</result>
+            def text='''{
+"succeeded": [],
+"failed": [
+    {
+        "index":1,
+        "name":"test00",
+        "group":"group00",
+        "project":"bongo",
+        "error":"Cannot create a Job with UUID 17b07de4-f47d-4ab1-9f3a-8d47b33058c4: a Job already exists..."
+    },
+    {
+        "index":2,
+        "name":"test01",
+        "group":"",
+        "project":"bongo",
+        "error":"...errr"
+    }
+],
+"skipped":[
+    {
+        "index":12,
+        "name":"test02",
+        "group":"group02",
+        "project":"bongo",
+        "error":"...errr"
+    },
+    {
+        "index":13,
+        "name":"test03",
+        "group":"",
+        "project":"bongo",
+        "error":"...errr"
+    }
+]
+}
 '''
             def retrofit = new Retrofit.Builder().baseUrl('http://test').
-                addConverterFactory(JaxbConverterFactory.create()).
+                addConverterFactory(JacksonConverterFactory.create()).
                 build()
 
         when:
             Converter<ResponseBody, ImportResult> converter = retrofit.
                 responseBodyConverter(ImportResult.class, [] as Annotation[],);
-            ImportResult result = converter.convert(ResponseBody.create(MediaType.parse('application/xml'), xmlText))
+            ImportResult result = converter.convert(ResponseBody.create(text, MediaType.parse('application/json')))
 
         then:
             result.succeeded!=null

--- a/rd-api-client/src/test/groovy/org/rundeck/client/api/model/JobLoadItemSpec.groovy
+++ b/rd-api-client/src/test/groovy/org/rundeck/client/api/model/JobLoadItemSpec.groovy
@@ -4,6 +4,7 @@ import okhttp3.MediaType
 import okhttp3.ResponseBody
 import retrofit2.Converter
 import retrofit2.Retrofit
+import retrofit2.converter.jackson.JacksonConverterFactory
 import retrofit2.converter.jaxb.JaxbConverterFactory
 import spock.lang.Specification
 
@@ -12,23 +13,25 @@ import java.lang.annotation.Annotation
 class JobLoadItemSpec extends Specification {
     def "parse job load item with empty job name"() {
         given:
-            def xmlText = '''
-    <job index='1' href='http://rundeck.local:4440/rundeck/api/34/job/896a3c9e-f765-43cc-8e1a-15566fe275fa'>
-      <id>896a3c9e-f765-43cc-8e1a-15566fe275fa</id>
-      <permalink>http://rundeck.local:4440/rundeck/project/asdf/job/show/896a3c9e-f765-43cc-8e1a-15566fe275fa</permalink>
-      <name></name>
-      <group>Sales</group>
-      <project>asdf</project>
-      <error>Job Name is required</error>
-    </job>'''
+            def jsonText = '''{
+    "index": 1,
+    "href": "http://rundeck.local:4440/rundeck/api/34/job/896a3c9e-f765-43cc-8e1a-15566fe275fa",
+    "id": "896a3c9e-f765-43cc-8e1a-15566fe275fa",
+    "permalink": "http://rundeck.local:4440/rundeck/project/asdf/job/show/896a3c9e-f765-43cc-8e1a-15566fe275fa",
+    "name": "",
+    "group": "Sales",
+    "project": "asdf",
+    "error": "Job Name is required"
+}
+'''
             def retrofit = new Retrofit.Builder().baseUrl('http://test').
-                    addConverterFactory(JaxbConverterFactory.create()).
+                    addConverterFactory(JacksonConverterFactory.create()).
                     build()
 
         when:
             Converter<ResponseBody, JobLoadItem> converter = retrofit.
                     responseBodyConverter(JobLoadItem.class, [] as Annotation[],);
-            JobLoadItem result = converter.convert(ResponseBody.create(MediaType.parse('application/xml'), xmlText))
+            JobLoadItem result = converter.convert(ResponseBody.create(jsonText, MediaType.parse('application/json')))
 
         then:
             result != null

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Executions.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Executions.java
@@ -700,12 +700,6 @@ public class Executions extends BaseCommand {
     @Setter
     static class MetricsCmd extends QueryOptions implements OutputFormat {
 
-        @CommandLine.Option(
-                names = {"--xml"},
-                description = "Get the result in raw xml. Note: cannot be combined with RD_FORMAT env variable.")
-        private boolean rawXML;
-
-
         @CommandLine.Option(names = {"--jobids", "-i"},
                 arity = "1..*",
                 description = "Job ID list to include")
@@ -736,33 +730,12 @@ public class Executions extends BaseCommand {
     public void metrics(@CommandLine.Mixin MetricsCmd options) throws IOException, InputError {
         getRdTool().requireApiVersion("metrics", 29);
 
-        // Check parameters.
-        if (!"xml".equalsIgnoreCase(getRdTool().getAppConfig().getString("RD_FORMAT", "xml")) && options.isRawXML()) {
-            throw new InputError("You cannot use RD_FORMAT env var with --xml");
-        }
-
         Map<String, String> query = createQueryParams(options, null, null);
 
         MetricsResponse result;
 
         // Case project wire.
         if (options.isProject()) {
-
-            // Raw XML
-            if ("XML".equalsIgnoreCase(getRdTool().getAppConfig().getString("RD_FORMAT", null)) || options.isRawXML()) {
-                try(ResponseBody response = apiCall(api -> api.executionMetricsXML(
-                        options.getProject(),
-                        query,
-                        options.getJobIdList(),
-                        options.getExcludeJobIdList(),
-                        options.getJobList(),
-                        options.getExcludeJobList()
-                ))) {
-                    getRdOutput().output(response.string());
-                }
-                return;
-            }
-
             // Get response.
             result = apiCall(api -> api.executionMetrics(
                     options.getProject(),
@@ -777,20 +750,6 @@ public class Executions extends BaseCommand {
 
         // Case system-wide
         else {
-
-            // Raw XML
-            if ("XML".equalsIgnoreCase(getRdTool().getAppConfig().getString("RD_FORMAT", null)) || options.isRawXML()) {
-                try(ResponseBody response = apiCall(api -> api.executionMetricsXML(
-                        query,
-                        options.getJobIdList(),
-                        options.getExcludeJobIdList(),
-                        options.getJobList(),
-                        options.getExcludeJobList()
-                ))) {
-                    getRdOutput().output(response.string());
-                }
-                return;
-            }
 
             // Get raw Json.
             result = apiCall(api -> api.executionMetrics(


### PR DESCRIPTION
Note: XML support has been deprecated in Rundeck API since version 4.0.0