### PR TITLE
RUN-2080: fix #538 format parameter overrides content type

### DIFF
--- a/rd-api-client/src/main/java/org/rundeck/client/api/RundeckApi.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/api/RundeckApi.java
@@ -211,7 +211,6 @@ public interface RundeckApi {
     Call<ImportResult> loadJobs(
             @Path("project") String project,
             @Body RequestBody body,
-            @Query("format") String format,
             @Query("dupeOption") String duplicate,
             @Query("uuidOption") String uuids
     );

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Jobs.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/Jobs.java
@@ -185,7 +185,6 @@ public class Jobs extends BaseCommand {
         ImportResult importResult = getRdTool().apiCall(api -> api.loadJobs(
                 project,
                 requestBody,
-                fileOptions.getFormat().toString(),
                 options.getDuplicate().toString(),
                 options.isRemoveUuids() ? UUID_REMOVE : UUID_PRESERVE
         ));

--- a/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/JobsSpec.groovy
+++ b/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/JobsSpec.groovy
@@ -463,7 +463,7 @@ class JobsSpec extends Specification {
         def result = command.load(new JobLoadOptions(), opts,new ProjectNameOptions(project:'ProjectName'),new VerboseOption())
 
         then:
-        1 * api.loadJobs('ProjectName', _, 'yaml', _, _) >>
+        1 * api.loadJobs('ProjectName', _, _, _) >>
                 Calls.response(new ImportResult(succeeded: [], skipped: [], failed: [
                         new JobLoadItem(error: 'Test Error', name: 'Job Name')
                 ]
@@ -496,7 +496,7 @@ class JobsSpec extends Specification {
         then:
         1 * api.loadJobs('ProjectName', { RequestBody body->
             body.contentType()==expectedType
-        }, format.toString(), _, _) >>
+        }, _, _) >>
                 Calls.response(new ImportResult(succeeded: [new JobLoadItem( id:'jobid',name: 'Job Name')], skipped: [], failed: []))
         0 * api._(*_)
         1 * out.info('1 Jobs Succeeded:\n')
@@ -529,7 +529,7 @@ class JobsSpec extends Specification {
             def result = command.load(new JobLoadOptions(), opts,new ProjectNameOptions(project:'ProjectName'),new VerboseOption(verbose: true))
 
         then:
-            1 * api.loadJobs('ProjectName', _, 'yaml', _, _) >>
+            1 * api.loadJobs('ProjectName', _, _, _) >>
             Calls.response(new ImportResult(succeeded: [], skipped: [], failed: [resultItem]))
             0 * api._(*_)
             1 * out.info('1 Jobs Failed:\n')


### PR DESCRIPTION
the `format` URL parameter in job load API request overrides the Accept header to define the response content type.

Remove the parameter and let the Accept header determine response format.