### PR TITLE
RSE-955 FIX: Allow update existing webhooks at project import

### DIFF
--- a/rd-api-client/src/main/java/org/rundeck/client/api/RundeckApi.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/api/RundeckApi.java
@@ -411,6 +411,7 @@ public interface RundeckApi {
             @Query("importScm") Boolean importScm,
             @Query("importWebhooks") Boolean importWebhooks,
             @Query("whkRegenAuthTokens") Boolean whkRegenAuthTokens,
+            @Query("whkRegenUuid") Boolean whkRegenUuid,
             @Query("importNodesSources") Boolean importNodesSources,
             @Query("asyncImport") Boolean asyncImport,
             @QueryMap Map<String,String> params,

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/projects/Archives.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/projects/Archives.java
@@ -94,7 +94,7 @@ public class Archives extends BaseCommand  {
         @CommandLine.Option(names = {"-t", "--regenerate-tokens"}, description = "regenerate the auth tokens associated with the webhook in import, default: false (api v34 required)")
         boolean whkRegenAuthTokens;
 
-        @CommandLine.Option(names = {"-R", "--remove-webhooks-uuids"}, description = "Remove Webhooks UUIDs in import. Default: preserve webhooks UUIDs. (api v34 required)")
+        @CommandLine.Option(names = {"-R", "--remove-webhooks-uuids"}, description = "Remove Webhooks UUIDs in import. Default: preserve webhooks UUIDs. (api v47 required)")
         boolean whkRegenUuid;
 
         @CommandLine.Option(names = {"-n", "--include-node-sources"}, description = "Include node resources in import, default: false (api v38 required)")
@@ -145,8 +145,8 @@ public class Archives extends BaseCommand  {
         if ((opts.isIncludeWebhooks() || opts.isWhkRegenAuthTokens()) && getRdTool().getClient().getApiVersion() < 34) {
             throw new InputError(String.format("Cannot use --include-webhooks or --regenerate-tokens with API < 34 (currently: %s)", getRdTool().getClient().getApiVersion()));
         }
-        if ((opts.isIncludeWebhooks() || opts.isWhkRegenUuid()) && getRdTool().getClient().getApiVersion() < 34) {
-            throw new InputError(String.format("Cannot use --include-webhooks or --remove-webhooks-uuids with API < 34 (currently: %s)", getRdTool().getClient().getApiVersion()));
+        if ((opts.isIncludeWebhooks() || opts.isWhkRegenUuid()) && getRdTool().getClient().getApiVersion() < 47) {
+            throw new InputError(String.format("Cannot use --include-webhooks or --remove-webhooks-uuids with API < 47 (currently: %s)", getRdTool().getClient().getApiVersion()));
         }
         if ((opts.isIncludeNodeSources()) && getRdTool().getClient().getApiVersion() < 38) {
             throw new InputError(String.format("Cannot use --include-node-sources with API < 38 (currently: %s)", getRdTool().getClient().getApiVersion()));

--- a/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/projects/Archives.java
+++ b/rd-cli-tool/src/main/java/org/rundeck/client/tool/commands/projects/Archives.java
@@ -94,6 +94,9 @@ public class Archives extends BaseCommand  {
         @CommandLine.Option(names = {"-t", "--regenerate-tokens"}, description = "regenerate the auth tokens associated with the webhook in import, default: false (api v34 required)")
         boolean whkRegenAuthTokens;
 
+        @CommandLine.Option(names = {"-R", "--remove-webhooks-uuids"}, description = "Remove Webhooks UUIDs in import. Default: preserve webhooks UUIDs. (api v34 required)")
+        boolean whkRegenUuid;
+
         @CommandLine.Option(names = {"-n", "--include-node-sources"}, description = "Include node resources in import, default: false (api v38 required)")
         boolean includeNodeSources;
 
@@ -142,6 +145,9 @@ public class Archives extends BaseCommand  {
         if ((opts.isIncludeWebhooks() || opts.isWhkRegenAuthTokens()) && getRdTool().getClient().getApiVersion() < 34) {
             throw new InputError(String.format("Cannot use --include-webhooks or --regenerate-tokens with API < 34 (currently: %s)", getRdTool().getClient().getApiVersion()));
         }
+        if ((opts.isIncludeWebhooks() || opts.isWhkRegenUuid()) && getRdTool().getClient().getApiVersion() < 34) {
+            throw new InputError(String.format("Cannot use --include-webhooks or --remove-webhooks-uuids with API < 34 (currently: %s)", getRdTool().getClient().getApiVersion()));
+        }
         if ((opts.isIncludeNodeSources()) && getRdTool().getClient().getApiVersion() < 38) {
             throw new InputError(String.format("Cannot use --include-node-sources with API < 38 (currently: %s)", getRdTool().getClient().getApiVersion()));
         }
@@ -168,6 +174,7 @@ public class Archives extends BaseCommand  {
                 opts.isIncludeScm(),
                 opts.isIncludeWebhooks(),
                 opts.isWhkRegenAuthTokens(),
+                opts.isWhkRegenUuid(),
                 opts.isIncludeNodeSources(),
                 opts.isAsyncImportEnabled(),
                 extraCompOpts,

--- a/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/projects/ArchivesSpec.groovy
+++ b/rd-cli-tool/src/test/groovy/org/rundeck/client/tool/commands/projects/ArchivesSpec.groovy
@@ -72,6 +72,7 @@ class ArchivesSpec extends Specification {
                 _,
                 _,
                 _,
+                _,
                 [
                         'importComponents.test-comp': 'true',
                         'importOpts.test-comp.key'  : 'value',
@@ -115,6 +116,7 @@ class ArchivesSpec extends Specification {
         then:
         1 * api.importProjectArchive(
                 'Aproj',
+                _,
                 _,
                 _,
                 _,
@@ -194,6 +196,7 @@ class ArchivesSpec extends Specification {
         then:
         1 * api.importProjectArchive(
                 'Aproj',
+                _,
                 _,
                 _,
                 _,


### PR DESCRIPTION
Problem: When exporting a project and then importing into another instance, the Project Import feature fails to import webhooks if they already exist in the current project. Consequently, the webhook definitions are not updated.

Expected Outcome: Rundeck should treat webhook as it treats jobs when imported. 

Proposed Solution: If a Webhook is being imported and should update an existing Webhook use the same UUID when saving the updated Webhook, this small change allows Webhooks to be updated when exported and imported over itself. Also, a new option should be added when importing a project to allow users to keep the same webhook UUID or generate new ones. By making these changes the Webhooks would be handled in the same way jobs are handled when a Project is imported over itself. 

Related to this PR already merged https://github.com/rundeck/rundeck/pull/8892