### PR TITLE
Fix Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "postUpgradeTasks": {
     "commands": [
@@ -11,7 +11,7 @@
       "gradle/verification-keyring.keys"
     ]
   },
-  "allowedCommands: [
+  "allowedCommands": [
     "^./gradlew --write-verification-metadata pgp,sha256 --export-keys help$"
   ]
 }


### PR DESCRIPTION
This is a small Renovate config cleanup for the current stop-PR issue (#604) and dashboard migration note (#385).

What changed:
- fixes the malformed `allowedCommands` key so `renovate.json` parses as JSON again
- updates the deprecated `config:base` preset to `config:recommended`
- leaves the existing Gradle verification post-upgrade task and allowed command unchanged

Validation:
- `python3 -m json.tool renovate.json`

This is intentionally narrow and reversible so Renovate can resume opening/updating dependency PRs.