### PR TITLE
[RUN-4639] Publish CLI Maven artifacts to PackageCloud instead of Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
             ./rd-cli-lib/build/libs/rd-cli-lib-*.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to PackageCloud
+      - name: Publish Maven artifacts to PackageCloud
         run: |
           if [ -z "$PKGCLD_WRITE_TOKEN" ]; then
             echo "::error::PKGCLD_WRITE_TOKEN must be set to publish to PackageCloud"
@@ -110,7 +110,7 @@ jobs:
       - name: Install packagecloud.io CLI
         run: |
           gem install package_cloud
-      - name: Publish to Packagecloud
+      - name: Publish OS packages (deb/rpm) to PackageCloud
         run: |
             package_cloud push pagerduty/rundeck/any/any rd-cli-tool/build/distributions/rundeck-cli_*-1_all.deb
             package_cloud push pagerduty/rundeckpro/any/any rd-cli-tool/build/distributions/rundeck-cli_*-1_all.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   publish:
 
     runs-on: ubuntu-22.04
+    env:
+      PKGCLD_REPO_URL: ${{ vars.PKGCLD_REPO_URL }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -47,13 +49,60 @@ jobs:
             ./rd-cli-lib/build/libs/rd-cli-lib-*.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to Maven Central
-        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} publishToSonatype closeAndReleaseSonatypeStagingRepository
+      - name: Publish to PackageCloud
+        run: |
+          if [ -z "$PKGCLD_WRITE_TOKEN" ]; then
+            echo "::error::PKGCLD_WRITE_TOKEN must be set to publish to PackageCloud"
+            exit 1
+          fi
+          ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
+      - name: Sign and upload GPG signatures to PackageCloud
+        run: |
+          set -e
+          VERSION="${GITHUB_REF_NAME#v}"
+          BASE_URL="${PKGCLD_REPO_URL:-https://packagecloud.io/pagerduty/rundeck/maven2}"
+
+          echo "$SIGNING_KEY_B64" | base64 -d | gpg --batch --yes --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
+
+          sign_and_upload() {
+            local FILE="$1"
+            local REMOTE_URL="$2"
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$SIGNING_PASSWORD" --default-key "$KEY_ID" --detach-sign --armor "$FILE"
+            curl -sf -H "Authorization: Bearer ${PKGCLD_WRITE_TOKEN}" \
+              -X PUT --data-binary "@${FILE}.asc" \
+              "${REMOTE_URL}"
+          }
+
+          # rd-api-client: local build/libs filenames already match the published artifactId
+          RD_API_CLIENT_URL="${BASE_URL}/org/rundeck/api/rd-api-client/${VERSION}"
+          sign_and_upload "rd-api-client/build/libs/rd-api-client-${VERSION}.jar" "${RD_API_CLIENT_URL}/rd-api-client-${VERSION}.jar.asc"
+          sign_and_upload "rd-api-client/build/libs/rd-api-client-${VERSION}-sources.jar" "${RD_API_CLIENT_URL}/rd-api-client-${VERSION}-sources.jar.asc"
+          sign_and_upload "rd-api-client/build/libs/rd-api-client-${VERSION}-javadoc.jar" "${RD_API_CLIENT_URL}/rd-api-client-${VERSION}-javadoc.jar.asc"
+          sign_and_upload "rd-api-client/build/publications/rd-api-client/pom-default.xml" "${RD_API_CLIENT_URL}/rd-api-client-${VERSION}.pom.asc"
+
+          # rd-cli-lib: local build/libs filenames already match the published artifactId
+          RD_CLI_LIB_URL="${BASE_URL}/org/rundeck/cli/rd-cli-lib/${VERSION}"
+          sign_and_upload "rd-cli-lib/build/libs/rd-cli-lib-${VERSION}.jar" "${RD_CLI_LIB_URL}/rd-cli-lib-${VERSION}.jar.asc"
+          sign_and_upload "rd-cli-lib/build/libs/rd-cli-lib-${VERSION}-sources.jar" "${RD_CLI_LIB_URL}/rd-cli-lib-${VERSION}-sources.jar.asc"
+          sign_and_upload "rd-cli-lib/build/libs/rd-cli-lib-${VERSION}-javadoc.jar" "${RD_CLI_LIB_URL}/rd-cli-lib-${VERSION}-javadoc.jar.asc"
+          sign_and_upload "rd-cli-lib/build/publications/rd-cli-lib/pom-default.xml" "${RD_CLI_LIB_URL}/rd-cli-lib-${VERSION}.pom.asc"
+
+          # rd-cli-tool: archivesBaseName is 'rundeck-cli', so LOCAL filenames differ from the
+          # published Maven artifactId 'rd-cli-tool' -- sign the local files, upload under the
+          # published coordinate name.
+          RD_CLI_TOOL_URL="${BASE_URL}/org/rundeck/rd/rd-cli-tool/${VERSION}"
+          sign_and_upload "rd-cli-tool/build/libs/rundeck-cli-${VERSION}.jar" "${RD_CLI_TOOL_URL}/rd-cli-tool-${VERSION}.jar.asc"
+          sign_and_upload "rd-cli-tool/build/libs/rundeck-cli-${VERSION}-sources.jar" "${RD_CLI_TOOL_URL}/rd-cli-tool-${VERSION}-sources.jar.asc"
+          sign_and_upload "rd-cli-tool/build/libs/rundeck-cli-${VERSION}-javadoc.jar" "${RD_CLI_TOOL_URL}/rd-cli-tool-${VERSION}-javadoc.jar.asc"
+          sign_and_upload "rd-cli-tool/build/libs/rundeck-cli-${VERSION}-all.jar" "${RD_CLI_TOOL_URL}/rd-cli-tool-${VERSION}-all.jar.asc"
+          sign_and_upload "rd-cli-tool/build/publications/rd-cli-tool/pom-default.xml" "${RD_CLI_TOOL_URL}/rd-cli-tool-${VERSION}.pom.asc"
+        env:
           SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@
 plugins {
     id 'base'
     alias(libs.plugins.axion)
-    alias(libs.plugins.nexusPublish)
 }
 import java.util.regex.Matcher
 import pl.allegro.tech.build.axion.release.domain.VersionConfig
@@ -218,13 +217,3 @@ tasks.register('changeLog'){
 }
 
 
-nexusPublishing {
-    packageGroup = 'org.rundeck'
-    repositories {
-        sonatype{
-            stagingProfileId = '67d196ce5bae'
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-        }
-    }
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ junit = "4.13.2"
 groovy = "4.0.32"
 spock = "2.3-groovy-4.0"
 axion = "1.21.2"
-nexusPublish = "1.3.0"
 shadow = "8.1.1"
 ospackage = "11.11.2"
 buildInfo = "0.9"
@@ -65,7 +64,6 @@ rundeckAuthz = ["rundeckAuthzCore", "rundeckAuthzApi", "rundeckAuthzYaml"]
 [plugins]
 
 axion = { id = "pl.allegro.tech.build.axion-release", version.ref = "axion" }
-nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
 ospackage = { id = "com.netflix.nebula.ospackage", version.ref = "ospackage" }
 buildInfo = { id = "org.dvaske.gradle.git-build-info", version.ref = "buildInfo" }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -7,17 +7,12 @@
  * githubSlug = Github slug e.g. 'rundeck/rundeck-cli'
  * developers = [ [id:'id', name:'name', email: 'email' ] ] list of developers
  *
- * Define project properties to sign and publish when invoking publish task:
- *
- *     ./gradlew \
- *     -PsigningKey="base64 encoded gpg key" \
- *     -PsigningPassword="password for key" \
- *     -PsonatypeUsername="sonatype token user" \
- *     -PsonatypePassword="sonatype token password" \
- *     publishToSonatype closeAndReleaseSonatypeStagingRepository
+ * Publishes to PackageCloud via PKGCLD_REPO_URL / PKGCLD_WRITE_TOKEN env vars.
+ * Signing happens separately in the release workflow via gpg/curl, not here.
  */
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
+
+def pkgcldRepoUrl = (System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeck/maven2").trim()
 
 publishing {
     publications {
@@ -60,16 +55,17 @@ publishing {
 
         }
     }
-}
-def base64Decode = { String prop ->
-    project.findProperty(prop) ?
-    new String(Base64.getDecoder().decode(project.findProperty(prop).toString())).trim() :
-    null
-}
-
-if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
-    signing {
-        useInMemoryPgpKeys(base64Decode("signingKey"), project.signingPassword)
-        sign(publishing.publications)
+    repositories {
+        maven {
+            name = "PackageCloud"
+            url = uri(pkgcldRepoUrl)
+            authentication {
+                header(HttpHeaderAuthentication)
+            }
+            credentials(HttpHeaderCredentials) {
+                name = "Authorization"
+                value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
+            }
+        }
     }
 }


### PR DESCRIPTION
## Jira ticket

[RUN-4639](https://pagerduty.atlassian.net/browse/RUN-4639)

## Description

`org.rundeck` is over Maven Central's free publishing limits (RUN-4570); Sonatype begins rate-limiting publishing on 2026-08-11. This applies the same PackageCloud migration already validated end-to-end on the `rundeck-plugins` org repos (RUN-4638) to this repo's 3 Maven modules: `rd-api-client`, `rd-cli-lib`, and `rd-cli-tool`.

- Removes the `nexus-publish` plugin and `nexusPublishing {}` block.
- Registers PackageCloud (`https://packagecloud.io/pagerduty/rundeck/maven2`) as the publishing repository in `gradle/publishing.gradle`, reusing the same PackageCloud repo the CLI's `.deb`/`.rpm` already publish to — no new PackageCloud repo needed.
- Signs artifacts with the `gpg` CLI and uploads signatures via `curl` in `release.yml`, instead of Gradle's `signing` plugin: Gradle auto-generates a checksum for every publication artifact including `.asc` files, and PackageCloud's Maven endpoint 422s on the checksum-of-a-signature-file, aborting the publish task partway through.
- `rd-cli-tool` sets `archivesBaseName='rundeck-cli'`, so its local build output filenames (`rundeck-cli-<version>*.jar`) differ from its published Maven artifactId (`rd-cli-tool`) — the signing step signs the local files but uploads the `.asc` under the published coordinate name.

Existing versions already published on Maven Central are unaffected — only future releases move to PackageCloud only. The GitHub Release step and the existing `.deb`/`.rpm` PackageCloud push are untouched.

## Testing instructions

- `./gradlew clean build` passes locally with all tests (verified: `BUILD SUCCESSFUL`, 75 tasks, all 3 modules + `integration-tests`).
- `./gradlew tasks --all` confirms `publishAllPublicationsToPackageCloudRepository` exists for `rd-api-client`, `rd-cli-lib`, and `rd-cli-tool`.
- `./gradlew build` still succeeds with no `PKGCLD_REPO_URL`/`PKGCLD_WRITE_TOKEN` set (the `gradle.yml` CI workflow is unaffected — the fallback default in `publishing.gradle` avoids a null-URL crash).
- To fully verify: push a test tag to trigger `release.yml`, confirm the 3 artifacts (plus `-sources`/`-javadoc`, and `rd-cli-tool`'s `-all` jar) and their `.asc` signatures land under `https://packagecloud.io/pagerduty/rundeck/maven2/org/rundeck/...`, and confirm `PKGCLD_WRITE_TOKEN`/`SIGNING_KEY_B64`/`SIGNING_PASSWORD` secrets are available to this workflow.


[RUN-4639]: https://pagerduty.atlassian.net/browse/RUN-4639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ