### PR TITLE
[RUN-4856] Fix RD_BYPASS_URL being ignored due to interceptor ordering

### DIFF
--- a/rd-api-client/src/main/java/org/rundeck/client/RundeckClient.java
+++ b/rd-api-client/src/main/java/org/rundeck/client/RundeckClient.java
@@ -105,12 +105,18 @@ public class RundeckClient {
             writeTimeout(config.getLong(ENV_HTTP_WRITE_TIMEOUT, null));
             timeout(config.getLong(ENV_HTTP_TIMEOUT, null));
             callTimeout(config.getLong(ENV_HTTP_CALL_TIMEOUT, null));
-            bypassUrl(config.getString(ENV_BYPASS_URL, null));
             insecureSSL(config.getBool(ENV_INSECURE_SSL, false));
             insecureSSLHostname(config.getBool(ENV_INSECURE_SSL_HOSTNAME, false));
             alternateSSLHostname(config.getString(ENV_ALT_SSL_HOSTNAME, null));
             allowVersionDowngrade(config.getBool(RD_API_DOWNGRADE, false));
+            // CrossOriginRedirectInterceptor must be added as a network interceptor before
+            // RedirectBypassInterceptor: OkHttp network interceptors see the response in the
+            // reverse of the order they were added, so adding this one first means it evaluates
+            // the redirect *after* RedirectBypassInterceptor has already rewritten the Location
+            // header to the app base URL, rather than blocking the original (cross-origin) bypass
+            // URL before it gets a chance to be rewritten.
             allowCrossOriginRedirect(config.getBool(ENV_ALLOW_CROSS_ORIGIN_REDIRECT, false));
+            bypassUrl(config.getString(ENV_BYPASS_URL, null));
             return this;
         }
 

--- a/rd-api-client/src/test/groovy/org/rundeck/client/RundeckClientRedirectBypassSpec.groovy
+++ b/rd-api-client/src/test/groovy/org/rundeck/client/RundeckClientRedirectBypassSpec.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.client
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.rundeck.client.util.RdClientConfig
+import spock.lang.Specification
+
+/**
+ * Regression test for https://github.com/rundeck/rundeck-cli/issues/614 :
+ * RD_BYPASS_URL was ignored because the CrossOriginRedirectInterceptor (added by
+ * RD_ALLOW_CROSS_ORIGIN_REDIRECT handling) evaluated the raw, un-rewritten redirect
+ * Location before RedirectBypassInterceptor got a chance to rewrite it back to the
+ * app's own base URL, so legitimate bypass redirects were blocked as if they were
+ * cross-origin.
+ */
+class RundeckClientRedirectBypassSpec extends Specification {
+    MockWebServer server
+
+    def setup() {
+        server = new MockWebServer()
+        server.start()
+    }
+
+    def cleanup() {
+        server.shutdown()
+    }
+
+    private RdClientConfig configWithBypassUrl(final String bypassUrl) {
+        Stub(RdClientConfig) {
+            getString(_, _) >> {
+                String key, String defval -> key == RundeckClient.ENV_BYPASS_URL ? bypassUrl : defval
+            }
+            getBool(_, _) >> { String key, boolean defval -> defval }
+            getLong(_, _) >> { String key, Long defval -> defval }
+            getInt(_, _) >> { String key, int defval -> defval }
+            getDebugLevel() >> 0
+        }
+    }
+
+    def "redirect to RD_BYPASS_URL is rewritten and not blocked as cross-origin"() {
+        given: "a client configured with RD_BYPASS_URL pointing at an external host"
+        def baseUrl = server.url("/").toString()
+        def bypassUrl = "https://myhost.example.com"
+
+        def builder = RundeckClient.builder()
+                                    .baseUrl(baseUrl)
+                                    .config(configWithBypassUrl(bypassUrl))
+
+        OkHttpClient client = builder.okhttp.build()
+
+        server.enqueue(
+                new MockResponse()
+                        .setResponseCode(302)
+                        .setHeader("Location", "${bypassUrl}/api/29/system/info")
+        )
+        server.enqueue(new MockResponse().setResponseCode(200).setBody('ok'))
+
+        def request = new Request.Builder().url("${baseUrl}api/29/system/info").build()
+
+        when: "the server redirects to the bypass URL"
+        def response = client.newCall(request).execute()
+
+        then: "the redirect is rewritten back to the local base URL and followed successfully"
+        response.code() == 200
+        response.body().string() == 'ok'
+    }
+
+    def "redirect to an unrelated host is still blocked even when RD_BYPASS_URL is set"() {
+        given: "a client configured with RD_BYPASS_URL, but the redirect points elsewhere"
+        def baseUrl = server.url("/").toString()
+        def bypassUrl = "https://myhost.example.com"
+
+        def builder = RundeckClient.builder()
+                                    .baseUrl(baseUrl)
+                                    .config(configWithBypassUrl(bypassUrl))
+
+        OkHttpClient client = builder.okhttp.build()
+
+        server.enqueue(
+                new MockResponse()
+                        .setResponseCode(302)
+                        .setHeader("Location", "http://attacker.example.com/capture")
+        )
+
+        def request = new Request.Builder().url("${baseUrl}api/29/system/info").build()
+
+        when:
+        client.newCall(request).execute()
+
+        then:
+        IOException e = thrown()
+        e.message.contains('Cross-origin redirect blocked')
+    }
+}


### PR DESCRIPTION
## Jira ticket

[RUN-4856](https://pagerduty.atlassian.net/browse/RUN-4856)

## Description

Fixes [#614](https://github.com/rundeck/rundeck-cli/issues/614): `RD_BYPASS_URL` was being ignored, with requests failing with "Cross-origin redirect blocked for security".

`RUN-4466` added `CrossOriginRedirectInterceptor` as an OkHttp network interceptor to block cross-origin redirects by default. In `RundeckClient.Builder#config()`, it was registered *after* `RedirectBypassInterceptor` (used for `RD_BYPASS_URL`). Because OkHttp network interceptors process the response in the reverse of the order they were added, `CrossOriginRedirectInterceptor` (added second) actually saw the raw response first — including the original, un-rewritten `Location` header from `RD_BYPASS_URL`, which is legitimately cross-origin relative to `RD_URL`. It threw before `RedirectBypassInterceptor` ever got a chance to rewrite the redirect back to the local app URL.

The fix swaps the registration order so `CrossOriginRedirectInterceptor` is added first (and evaluates the response last, after the bypass rewrite has already applied), with a comment explaining why the order matters.

## Testing instructions

- Added `RundeckClientRedirectBypassSpec` (`rd-api-client`), which uses a `MockWebServer` to verify:
  - a redirect to `RD_BYPASS_URL` is rewritten and followed successfully (reproduces the reported bug — confirmed it fails without the fix and passes with it)
  - a redirect to an unrelated host is still blocked, confirming the RUN-4466 security behavior is unchanged
- Ran the full `rd-api-client` and `rd-cli-tool` test suites: `./gradlew :rd-api-client:test :rd-cli-tool:test` — all pass.


[RUN-4856]: https://pagerduty.atlassian.net/browse/RUN-4856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ